### PR TITLE
docs(readme): reframe positioning and link web benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,31 @@ One Rust core, one display list, every platform renders natively.
 ```
 
 **[→ Live Demo](https://erweixin.github.io/RaTeX/demo/live.html)** — type LaTeX and compare RaTeX vs KaTeX side-by-side ·
-**[→ Support table](https://erweixin.github.io/RaTeX/demo/support-table.html)** — RaTeX vs KaTeX across all test formulas
+**[→ Support table](https://erweixin.github.io/RaTeX/demo/support-table.html)** — RaTeX vs KaTeX across all test formulas ·
+**[→ Web benchmark](https://erweixin.github.io/RaTeX/demo/benchmark.html)** — head-to-head perf in the browser
 
 ---
 
 ## Why RaTeX?
 
-Every major cross-platform math renderer today runs LaTeX through a browser or JavaScript engine — a hidden WebView eating 50–150 MB RAM, startup latency before the first formula, no offline guarantee.
+Every major cross-platform math renderer today runs LaTeX through a browser or JavaScript engine — a hidden WebView eating 50–150 MB RAM, startup latency before the first formula, no offline guarantee. KaTeX is excellent on the web, but on every other surface — iOS, Android, Flutter, server-side, embedded — you're either hosting a WebView or shelling out to headless Chrome.
 
-RaTeX cuts the web stack out entirely:
+RaTeX is the same KaTeX-compatible math engine compiled to a portable Rust core, so the *same* renderer runs natively everywhere — and produces byte-identical output across every target.
 
-| | KaTeX (web) | MathJax | **RaTeX** |
+| | KaTeX | MathJax | **RaTeX** |
 |---|---|---|---|
-| Runtime | V8 + DOM | V8 + DOM | **Pure Rust** |
-| Mobile | WebView | WebView | **Native** |
+| Runtime | JS (V8) | JS (V8) | **Pure Rust** |
+| Surfaces it runs on | Web only* | Web only* | **iOS · Android · Flutter · RN · Web · server · SVG** |
+| Mobile | WebView wrapper | WebView wrapper | **Native** |
+| Server-side rendering | headless Chrome | mathjax-node | **Single binary, no JS runtime** |
+| Output substrate | DOM (`<span>` tree) | DOM / SVG | **Display list → Canvas / PNG / SVG** |
+| Memory | GC / heap | GC / heap | **Predictable, no GC** |
 | Offline | Depends | Depends | **Yes** |
-| Bundle overhead | ~280 kB JS | ~500 kB JS | **0 kB JS** |
-| Memory | GC / heap | GC / heap | **Predictable** |
 | Syntax coverage | 100% | ~100% | **~99%** |
+
+<sub>\* Embeddable in non-web targets only by hosting a WebView or headless browser, which most native and server contexts can't tolerate.</sub>
+
+**On the web specifically**, KaTeX has a decade of V8 JIT optimization behind it and remains the obvious choice for web-only projects. RaTeX's contribution isn't beating it on its home turf — it's being the only KaTeX-compatible engine that runs natively on every *other* surface, with pixel-identical output across all of them.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,24 +11,31 @@
 ```
 
 **[→ 在线演示](https://erweixin.github.io/RaTeX/demo/live.html)** — 输入 LaTeX，对比 RaTeX vs KaTeX ·
-**[→ 支持表](https://erweixin.github.io/RaTeX/demo/support-table.html)** — 全量测试公式的 RaTeX vs KaTeX 对比
+**[→ 支持表](https://erweixin.github.io/RaTeX/demo/support-table.html)** — 全量测试公式的 RaTeX vs KaTeX 对比 ·
+**[→ Web 性能基准](https://erweixin.github.io/RaTeX/demo/benchmark.html)** — 浏览器内的正面性能对比
 
 ---
 
 ## 为什么选 RaTeX？
 
-目前主流的跨平台数学渲染方案都依赖浏览器或 JavaScript 引擎跑 LaTeX，带来隐藏 WebView 占用 50–150 MB 内存、首屏公式要等 JS 启动、无法保证离线等问题。
+目前主流的跨平台数学渲染方案都依赖浏览器或 JavaScript 引擎跑 LaTeX，带来隐藏 WebView 占用 50–150 MB 内存、首屏公式要等 JS 启动、无法保证离线等问题。KaTeX 在 Web 上非常出色，但在其他任何目标——iOS、Android、Flutter、服务端、嵌入式——你要么内嵌 WebView，要么调用 headless Chrome。
 
-RaTeX 完全去掉 Web 栈：
+RaTeX 是同一个 KaTeX 兼容的数学引擎，但编译到一个可移植的 Rust 核心：**同一套渲染器在每个平台原生运行**，并在所有目标上产出**像素一致**的输出。
 
-| | KaTeX (Web) | MathJax | **RaTeX** |
+| | KaTeX | MathJax | **RaTeX** |
 |---|---|---|---|
-| 运行时 | V8 + DOM | V8 + DOM | **纯 Rust** |
-| 移动端 | WebView | WebView | **原生** |
+| 运行时 | JS (V8) | JS (V8) | **纯 Rust** |
+| 可运行的目标 | 仅 Web* | 仅 Web* | **iOS · Android · Flutter · RN · Web · 服务端 · SVG** |
+| 移动端 | WebView 套壳 | WebView 套壳 | **原生** |
+| 服务端渲染 | headless Chrome | mathjax-node | **单二进制，无需 JS 运行时** |
+| 输出形态 | DOM（`<span>` 树）| DOM / SVG | **显示列表 → Canvas / PNG / SVG** |
+| 内存模型 | GC / 堆 | GC / 堆 | **可预期，无 GC** |
 | 离线 | 视情况 | 视情况 | **支持** |
-| 包体积 | ~280 kB JS | ~500 kB JS | **0 kB JS** |
-| 内存模型 | GC / 堆 | GC / 堆 | **可预期** |
 | 语法覆盖 | 100% | ~100% | **~99%** |
+
+<sub>\* 在非 Web 目标上只能通过内嵌 WebView 或 headless 浏览器使用，而大多数原生和服务端场景都无法接受这种方式。</sub>
+
+**单看 Web**，KaTeX 背后有十年的 V8 JIT 优化积累，对纯 Web 项目仍然是显而易见的选择。RaTeX 的价值不在于在 KaTeX 的主场击败它，而在于：它是**唯一**一个能在所有其他平台原生运行的 KaTeX 兼容引擎，且在所有平台之间输出像素一致。
 
 ---
 

--- a/demo/benchmark.html
+++ b/demo/benchmark.html
@@ -74,8 +74,8 @@
     <div class="ctl">
       <label>Stage</label>
       <select id="stage">
+        <option value="full" selected>Full render (with draw)</option>
         <option value="parse">Parse + layout (no draw)</option>
-        <option value="full">Full render (with draw)</option>
       </select>
     </div>
     <button class="run-btn" id="run-btn" disabled>Run benchmark</button>


### PR DESCRIPTION
Companion to #30 and #32, addressing the framing problem raised in #31.

## What this changes

Rewrites the "Why RaTeX?" comparison table in both `README.md` and `README.zh-CN.md`. Nothing else in the README is touched, so the diff is small and easy to revert.

## Why

The current table sits RaTeX next to KaTeX/MathJax on a single set of axes (bundle size, runtime, syntax coverage), which accidentally implies they're alternatives at the same layer of abstraction. They aren't:

- **KaTeX is a web component.** It runs in V8, outputs DOM, and on the web specifically it's been JIT-optimized for a decade. On its home turf it's excellent and hard to beat.
- **RaTeX is a rendering primitive.** Its real contribution isn't "faster KaTeX on the web" — it's being the *only* KaTeX-compatible engine that runs natively on iOS, Android, Flutter, server-side, and SVG, with byte-identical output across all of them.

On every non-web target, KaTeX/MathJax simply aren't options without hosting a WebView or shelling out to headless Chrome — exactly the things RaTeX exists to avoid. The current table doesn't surface that asymmetry, so a reader skimming it walks away thinking "0 kB JS vs 280 kB JS, ok" and misses the actual story.

The benchmark in #30 makes this concrete from the other direction: on the web, parse-stage RaTeX is roughly comparable to KaTeX (and after #32 even closer), with most of the residual gap living in `wasm-bindgen`'s FFI boundary. So leading with web bundle size is *exactly* the framing where RaTeX looks weakest. The framing where it looks strongest — and where it's accurate — is "the only engine that gives you the same math renderer on every surface your product touches."

## Concrete edits

1. Replaced the comparison table with one that adds two honest rows:
   - **Surfaces it runs on** — exposes that KaTeX/MathJax are web-only*
   - **Server-side rendering** — `headless Chrome` / `mathjax-node` / `single binary, no JS runtime`
   
   Plus an `Output substrate` row (DOM tree vs display list) which is where most of RaTeX's "no DOM coupling" advantages actually come from.

2. Added a short qualifier paragraph **acknowledging KaTeX is still the right call for web-only projects**, so the framing is calibrated rather than boastful. This is important — overclaiming would be worse than the current understatement.

3. Linked the new web benchmark page (`demo/benchmark.html` from #30) alongside the existing live demo and support table.

4. Mirrored everything in `README.zh-CN.md` so the two versions stay in sync.

## What this PR is *not*

- Not rewriting the rest of the README — `Architecture`, `Quick start`, `Platform targets`, etc. are untouched.
- Not making any performance claims I can't back up with the benchmark in #30.
- Not removing anything substantive — every fact in the original table is still in the new one.

Happy to iterate on tone or wording if any of this comes off too strong, or revert specific rows if you'd rather a more conservative edit. The intent is just to stop the table from accidentally selling RaTeX short.

Refs: #31, #30, #32


---

## Update: also default the web benchmark to Full render

Added one small commit (`demo/benchmark.html`) that flips the default stage in the benchmark page from **Parse + layout (no draw)** to **Full render (with draw)**, and reorders the dropdown so Full render is listed first.

Reason: parse-only is the sub-stage where RaTeX is currently *weakest* (the residual gap is FFI/`JSON.parse` overhead — see #32 for the analysis), and it is also not what anyone actually does end-to-end. A first-time visitor landing on the benchmark page shouldnt see the most pessimistic slice of the pipeline by default — they should see the realistic full path, which is where RaTeX wins. Parse-only stays available for anyone diagnosing the boundary specifically.

This is in the same spirit as the README reframing in this PR: stop accidentally leading with the framing where RaTeX looks weakest.
