### PR TITLE
fix: add dashed line support across all platforms

### DIFF
--- a/crates/ratex-svg/src/lib.rs
+++ b/crates/ratex-svg/src/lib.rs
@@ -110,8 +110,8 @@ pub fn render_to_svg(list: &DisplayList, opts: &SvgOptions) -> String {
                 width,
                 thickness,
                 color,
-                ..
-            } => emit_line(&mut body, *x, *y, *width, *thickness, color, opts),
+                dashed,
+            } => emit_line(&mut body, *x, *y, *width, *thickness, color, *dashed, opts),
             DisplayItem::Rect {
                 x,
                 y,
@@ -136,10 +136,7 @@ fn wrap_svg(vb_w: f64, vb_h: f64, body: &str) -> String {
     let w = fmt_num(vb_w);
     let h = fmt_num(vb_h);
     format!(
-        r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" width="{w}" height="{h}">{body}</svg>"#,
-        w = w,
-        h = h,
-        body = body,
+        r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" width="{w}" height="{h}">{body}</svg>"#
     )
 }
 
@@ -263,6 +260,7 @@ fn emit_glyph_text(out: &mut String, g: GlyphEmit<'_>, opts: &SvgOptions) {
     );
 }
 
+#[allow(clippy::too_many_arguments)]
 fn emit_line(
     out: &mut String,
     x: f64,
@@ -270,24 +268,37 @@ fn emit_line(
     width: f64,
     thickness: f64,
     color: &Color,
+    dashed: bool,
     opts: &SvgOptions,
 ) {
     let em = opts.em_px();
     let x0 = tx(x, opts);
     let yc = ty(y, opts);
     let t = (thickness * em).max(1e-6);
-    let y0 = yc - t / 2.0;
     let w = width * em;
-    let fill = color_to_svg(color);
-    let x0s = fmt_num(x0);
-    let y0s = fmt_num(y0);
-    let ws = fmt_num(w);
-    let hs = fmt_num(t);
+    let stroke = color_to_svg(color);
     use std::fmt::Write;
-    let _ = write!(
-        out,
-        r#"<rect x="{x0s}" y="{y0s}" width="{ws}" height="{hs}" fill="{fill}"/>"#
-    );
+    if dashed {
+        let x0s = fmt_num(x0);
+        let ycs = fmt_num(yc);
+        let x1s = fmt_num(x0 + w);
+        let ts = fmt_num(t);
+        let dash = fmt_num(t * 3.0);
+        let _ = write!(
+            out,
+            r#"<line x1="{x0s}" y1="{ycs}" x2="{x1s}" y2="{ycs}" stroke="{stroke}" stroke-width="{ts}" stroke-dasharray="{dash} {dash}"/>"#
+        );
+    } else {
+        let y0 = yc - t / 2.0;
+        let x0s = fmt_num(x0);
+        let y0s = fmt_num(y0);
+        let ws = fmt_num(w);
+        let hs = fmt_num(t);
+        let _ = write!(
+            out,
+            r#"<rect x="{x0s}" y="{y0s}" width="{ws}" height="{hs}" fill="{stroke}"/>"#
+        );
+    }
 }
 
 fn emit_rect(

--- a/platforms/android/src/main/kotlin/io/ratex/DisplayList.kt
+++ b/platforms/android/src/main/kotlin/io/ratex/DisplayList.kt
@@ -40,6 +40,7 @@ sealed class DisplayItem {
         val width: Double,
         val thickness: Double,
         val color: RaTeXColor,
+        val dashed: Boolean = false,
     ) : DisplayItem()
 
     @Serializable @SerialName("Rect")
@@ -76,7 +77,7 @@ sealed class PathCommand {
         val x1: Double, val y1: Double,
         val x: Double,  val y: Double,
     ) : PathCommand()
-    @Serializable @SerialName("Close")   object Close : PathCommand()
+    @Serializable @SerialName("Close")   data object Close : PathCommand()
 }
 
 // MARK: - Color

--- a/platforms/android/src/main/kotlin/io/ratex/RaTeXRenderer.kt
+++ b/platforms/android/src/main/kotlin/io/ratex/RaTeXRenderer.kt
@@ -95,14 +95,28 @@ class RaTeXRenderer(
     }
 
     private fun drawLine(canvas: Canvas, l: DisplayItem.Line) {
-        val halfT = (l.thickness * fontSize / 2).toFloat()
+        val t = maxOf(0.5f, (l.thickness * fontSize).toFloat())
+        val halfT = t / 2f
         val left   = l.x.em()
         val top    = l.y.em() - halfT
         val right  = (l.x + l.width).em()
         val bottom = l.y.em() + halfT
-        paint.style = Paint.Style.FILL
         paint.applyColor(l.color)
-        canvas.drawRect(left, top, right, bottom, paint)
+        if (l.dashed) {
+            val dashLen = t * 3f
+            paint.style = Paint.Style.STROKE
+            paint.strokeWidth = t
+            paint.strokeCap = Paint.Cap.BUTT
+            paint.pathEffect = android.graphics.DashPathEffect(floatArrayOf(dashLen, dashLen), 0f)
+            val path = android.graphics.Path()
+            path.moveTo(left, l.y.em())
+            path.lineTo(right, l.y.em())
+            canvas.drawPath(path, paint)
+            paint.pathEffect = null
+        } else {
+            paint.style = Paint.Style.FILL
+            canvas.drawRect(left, top, right, bottom, paint)
+        }
     }
 
     private fun drawRect(canvas: Canvas, r: DisplayItem.Rect) {

--- a/platforms/flutter/lib/src/display_list.dart
+++ b/platforms/flutter/lib/src/display_list.dart
@@ -75,16 +75,18 @@ class GlyphPathItem extends DisplayItem {
 class LineItem extends DisplayItem {
   final double x, y, width, thickness;
   final RaTeXColor color;
+  final bool dashed;
 
   const LineItem({required this.x, required this.y,
                   required this.width, required this.thickness,
-                  required this.color});
+                  required this.color, this.dashed = false});
 
   factory LineItem.fromJson(Map<String, dynamic> j) => LineItem(
         x: (j['x'] as num).toDouble(), y: (j['y'] as num).toDouble(),
         width: (j['width'] as num).toDouble(),
         thickness: (j['thickness'] as num).toDouble(),
         color: RaTeXColor.fromJson(j['color'] as Map<String, dynamic>),
+        dashed: j['dashed'] as bool? ?? false,
       );
 }
 

--- a/platforms/flutter/lib/src/ratex_painter.dart
+++ b/platforms/flutter/lib/src/ratex_painter.dart
@@ -124,9 +124,29 @@ class RaTeXPainter extends CustomPainter {
   void _drawLine(Canvas canvas, LineItem l) {
     final t = math.max(0.5, _em(l.thickness));
     final halfT = t / 2;
-    canvas.drawRect(
-      Rect.fromLTWH(_em(l.x), _em(l.y) - halfT, _em(l.width), t),
-      _paint(l.color));
+    if (l.dashed) {
+      final paint = _paint(l.color)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = t
+        ..strokeCap = StrokeCap.butt;
+      final dashLen = t * 3;
+      final path = ui.Path();
+      final x0 = _em(l.x);
+      final y0 = _em(l.y);
+      final endX = x0 + _em(l.width);
+      var cx = x0;
+      while (cx < endX) {
+        path.moveTo(cx, y0);
+        final nx = math.min(cx + dashLen, endX);
+        path.lineTo(nx, y0);
+        cx += dashLen * 2;
+      }
+      canvas.drawPath(path, paint);
+    } else {
+      canvas.drawRect(
+        Rect.fromLTWH(_em(l.x), _em(l.y) - halfT, _em(l.width), t),
+        _paint(l.color));
+    }
   }
 
   void _drawRect(Canvas canvas, RectItem r) {

--- a/platforms/ios/Sources/Ratex/DisplayList.swift
+++ b/platforms/ios/Sources/Ratex/DisplayList.swift
@@ -98,6 +98,17 @@ public struct LineData: Codable {
     public let width: Double
     public let thickness: Double
     public let color: RaTeXColor
+    public let dashed: Bool
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        x         = try c.decode(Double.self, forKey: .x)
+        y         = try c.decode(Double.self, forKey: .y)
+        width     = try c.decode(Double.self, forKey: .width)
+        thickness = try c.decode(Double.self, forKey: .thickness)
+        color     = try c.decode(RaTeXColor.self, forKey: .color)
+        dashed    = try c.decodeIfPresent(Bool.self, forKey: .dashed) ?? false
+    }
 }
 
 public struct RectData: Codable {

--- a/platforms/ios/Sources/Ratex/RaTeXRenderer.swift
+++ b/platforms/ios/Sources/Ratex/RaTeXRenderer.swift
@@ -99,10 +99,22 @@ public struct RaTeXRenderer {
 
     private func drawLine(_ l: LineData, in ctx: CGContext) {
         ctx.saveGState()
-        ctx.setFillColor(cgColor(l.color))
-        let halfT = pt(l.thickness) / 2
-        ctx.fill(CGRect(x: pt(l.x), y: pt(l.y) - halfT,
-                        width: pt(l.width), height: pt(l.thickness)))
+        let t = max(0.5, pt(l.thickness))
+        let halfT = t / 2
+        if l.dashed {
+            ctx.setStrokeColor(cgColor(l.color))
+            ctx.setLineWidth(t)
+            ctx.setLineCap(.butt)
+            let dashLen = t * 3
+            ctx.setLineDash(phase: 0, lengths: [dashLen, dashLen])
+            ctx.move(to: CGPoint(x: pt(l.x), y: pt(l.y)))
+            ctx.addLine(to: CGPoint(x: pt(l.x) + pt(l.width), y: pt(l.y)))
+            ctx.strokePath()
+        } else {
+            ctx.setFillColor(cgColor(l.color))
+            ctx.fill(CGRect(x: pt(l.x), y: pt(l.y) - halfT,
+                            width: pt(l.width), height: t))
+        }
         ctx.restoreGState()
     }
 

--- a/platforms/react-native/android/src/main/kotlin/io/ratex/DisplayList.kt
+++ b/platforms/react-native/android/src/main/kotlin/io/ratex/DisplayList.kt
@@ -40,6 +40,7 @@ sealed class DisplayItem {
         val width: Double,
         val thickness: Double,
         val color: RaTeXColor,
+        val dashed: Boolean = false,
     ) : DisplayItem()
 
     @Serializable @SerialName("Rect")
@@ -76,7 +77,7 @@ sealed class PathCommand {
         val x1: Double, val y1: Double,
         val x: Double,  val y: Double,
     ) : PathCommand()
-    @Serializable @SerialName("Close")   object Close : PathCommand()
+    @Serializable @SerialName("Close")   data object Close : PathCommand()
 }
 
 // MARK: - Color

--- a/platforms/react-native/android/src/main/kotlin/io/ratex/RaTeXRenderer.kt
+++ b/platforms/react-native/android/src/main/kotlin/io/ratex/RaTeXRenderer.kt
@@ -90,14 +90,28 @@ class RaTeXRenderer(
     }
 
     private fun drawLine(canvas: Canvas, l: DisplayItem.Line) {
-        val halfT = (l.thickness * fontSize / 2).toFloat()
+        val t = maxOf(0.5f, (l.thickness * fontSize).toFloat())
+        val halfT = t / 2f
         val left   = l.x.em()
         val top    = l.y.em() - halfT
         val right  = (l.x + l.width).em()
         val bottom = l.y.em() + halfT
-        paint.style = Paint.Style.FILL
         paint.applyColor(l.color)
-        canvas.drawRect(left, top, right, bottom, paint)
+        if (l.dashed) {
+            val dashLen = t * 3f
+            paint.style = Paint.Style.STROKE
+            paint.strokeWidth = t
+            paint.strokeCap = Paint.Cap.BUTT
+            paint.pathEffect = android.graphics.DashPathEffect(floatArrayOf(dashLen, dashLen), 0f)
+            val path = android.graphics.Path()
+            path.moveTo(left, l.y.em())
+            path.lineTo(right, l.y.em())
+            canvas.drawPath(path, paint)
+            paint.pathEffect = null
+        } else {
+            paint.style = Paint.Style.FILL
+            canvas.drawRect(left, top, right, bottom, paint)
+        }
     }
 
     private fun drawRect(canvas: Canvas, r: DisplayItem.Rect) {

--- a/platforms/react-native/ios/DisplayList.swift
+++ b/platforms/react-native/ios/DisplayList.swift
@@ -92,6 +92,17 @@ public struct LineData: Codable {
     public let width: Double
     public let thickness: Double
     public let color: RaTeXColor
+    public let dashed: Bool
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        x         = try c.decode(Double.self, forKey: .x)
+        y         = try c.decode(Double.self, forKey: .y)
+        width     = try c.decode(Double.self, forKey: .width)
+        thickness = try c.decode(Double.self, forKey: .thickness)
+        color     = try c.decode(RaTeXColor.self, forKey: .color)
+        dashed    = try c.decodeIfPresent(Bool.self, forKey: .dashed) ?? false
+    }
 }
 
 public struct RectData: Codable {

--- a/platforms/react-native/ios/RaTeXRenderer.swift
+++ b/platforms/react-native/ios/RaTeXRenderer.swift
@@ -105,10 +105,22 @@ public struct RaTeXRenderer {
 
     private func drawLine(_ l: LineData, in ctx: CGContext) {
         ctx.saveGState()
-        ctx.setFillColor(cgColor(l.color))
-        let halfT = pt(l.thickness) / 2
-        ctx.fill(CGRect(x: pt(l.x), y: pt(l.y) - halfT,
-                        width: pt(l.width), height: pt(l.thickness)))
+        let t = max(0.5, pt(l.thickness))
+        let halfT = t / 2
+        if l.dashed {
+            ctx.setStrokeColor(cgColor(l.color))
+            ctx.setLineWidth(t)
+            ctx.setLineCap(.butt)
+            let dashLen = t * 3
+            ctx.setLineDash(phase: 0, lengths: [dashLen, dashLen])
+            ctx.move(to: CGPoint(x: pt(l.x), y: pt(l.y)))
+            ctx.addLine(to: CGPoint(x: pt(l.x) + pt(l.width), y: pt(l.y)))
+            ctx.strokePath()
+        } else {
+            ctx.setFillColor(cgColor(l.color))
+            ctx.fill(CGRect(x: pt(l.x), y: pt(l.y) - halfT,
+                            width: pt(l.width), height: t))
+        }
         ctx.restoreGState()
     }
 


### PR DESCRIPTION
## Summary
- Add missing `dashed` field to `DisplayItem.Line` (or equivalent) across Android, React Native (Android/iOS), Flutter, iOS, and ratex-svg — aligning with the JVM/web reference implementation
- Change `PathCommand.Close` from `object` to `data object` in React Native Android (consistent with JVM module)
- Implement dashed line rendering in all platform renderers (dash pattern: 3t on, 3t off)
- Handle `dashed` field in ratex-svg, emitting `<line stroke-dasharray>` instead of solid `<rect>`

## Affected platforms
| Platform | Data model | Renderer |
|----------|:---:|:---:|
| Android | `dashed` field added | `DashPathEffect` |
| React Native Android | `dashed` + `data object` | `DashPathEffect` |
| React Native iOS | `dashed` field added | `CGContext.setLineDash` |
| iOS | `dashed` field added | `CGContext.setLineDash` |
| Flutter | `dashed` field added | Manual dash path segments |
| ratex-svg | Already had field (was ignored) | `stroke-dasharray` |