### PR TITLE
feat: support transparent PNG rendering and CLI background color selection

### DIFF
--- a/crates/ratex-render/src/main.rs
+++ b/crates/ratex-render/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
         .iter()
         .position(|a| a == "--color")
         .and_then(|i| args.get(i + 1))
-        .map(|value| parse_color_arg(value))
+        .map(|value| parse_color_arg("--color", value))
         .transpose()
         .unwrap_or_else(|msg| {
             eprintln!("ERR {}", msg);
@@ -51,11 +51,24 @@ fn main() {
         })
         .unwrap_or(Color::BLACK);
 
+    let background_color = args
+        .iter()
+        .position(|a| a == "--background-color")
+        .and_then(|i| args.get(i + 1))
+        .map(|value| parse_color_arg("--background-color", value))
+        .transpose()
+        .unwrap_or_else(|msg| {
+            eprintln!("ERR {}", msg);
+            std::process::exit(2);
+        })
+        .unwrap_or(Color::WHITE);
+
     std::fs::create_dir_all(&output_dir).expect("Failed to create output dir");
 
     let options = RenderOptions {
         font_size,
         padding: 10.0,
+        background_color,
         font_dir,
         device_pixel_ratio,
     };
@@ -121,11 +134,11 @@ fn default_font_dir() -> String {
     "fonts".to_string()
 }
 
-fn parse_color_arg(value: &str) -> Result<Color, String> {
+fn parse_color_arg(flag: &str, value: &str) -> Result<Color, String> {
     Color::parse(value).ok_or_else(|| {
         format!(
-            "invalid --color '{}': expected a named color, #rgb, #rrggbb, or [MODEL]value",
-            value
+            "invalid {} '{}': expected a named color, #rgb, #rrggbb, or [MODEL]value",
+            flag, value
         )
     })
 }

--- a/crates/ratex-render/src/renderer.rs
+++ b/crates/ratex-render/src/renderer.rs
@@ -702,10 +702,8 @@ fn render_line(
             }
             cur_x += period;
         }
-    } else {
-        if let Some(rect) = tiny_skia::Rect::from_xywh(x, y - t / 2.0, width, t) {
-            pixmap.fill_rect(rect, &paint, Transform::identity(), None);
-        }
+    } else if let Some(rect) = tiny_skia::Rect::from_xywh(x, y - t / 2.0, width, t) {
+        pixmap.fill_rect(rect, &paint, Transform::identity(), None);
     }
 }
 

--- a/crates/ratex-render/src/renderer.rs
+++ b/crates/ratex-render/src/renderer.rs
@@ -12,6 +12,8 @@ use tiny_skia::{
 pub struct RenderOptions {
     pub font_size: f32,
     pub padding: f32,
+    /// Background fill color for the output PNG. Set alpha to 0.0 for transparency.
+    pub background_color: Color,
     /// Directory containing KaTeX `*.ttf` files. Required KaTeX faces are loaded lazily;
     /// rendering fails if a face referenced by the display list is missing.
     pub font_dir: String,
@@ -25,6 +27,7 @@ impl Default for RenderOptions {
         Self {
             font_size: 40.0,
             padding: 10.0,
+            background_color: Color::WHITE,
             font_dir: String::new(),
             device_pixel_ratio: 1.0,
         }
@@ -51,7 +54,7 @@ pub fn render_to_png(
     let mut pixmap = Pixmap::new(img_w, img_h)
         .ok_or_else(|| format!("Failed to create pixmap {}x{}", img_w, img_h))?;
 
-    pixmap.fill(tiny_skia::Color::WHITE);
+    pixmap.fill(to_tiny_skia_color(options.background_color));
 
     // Lazy font loading is shared across renderers and source-aware by font_dir.
     render_with_fonts(&mut pixmap, display_list, options, em_px, pad_px, dpr)?;
@@ -72,6 +75,16 @@ fn render_with_fonts(
     let font_refs = build_font_refs(&fonts)?;
     render_display_list(pixmap, display_list, &font_refs, em_px, pad_px, dpr);
     Ok(())
+}
+
+fn to_tiny_skia_color(color: Color) -> tiny_skia::Color {
+    tiny_skia::Color::from_rgba(
+        color.r.clamp(0.0, 1.0),
+        color.g.clamp(0.0, 1.0),
+        color.b.clamp(0.0, 1.0),
+        color.a.clamp(0.0, 1.0),
+    )
+    .unwrap_or(tiny_skia::Color::TRANSPARENT)
 }
 
 /// Build a `FontId → FontRef` map from the raw font data (borrowed from the cache lock).

--- a/crates/ratex-render/tests/bench_render.rs
+++ b/crates/ratex-render/tests/bench_render.rs
@@ -291,6 +291,7 @@ fn bench_render_100() {
     let render_opts = RenderOptions {
         font_size: 40.0,
         padding: 10.0,
+        background_color: ratex_types::color::Color::WHITE,
         font_dir,
         device_pixel_ratio: 1.0,
     };

--- a/crates/ratex-render/tests/font_cache_timing.rs
+++ b/crates/ratex-render/tests/font_cache_timing.rs
@@ -25,6 +25,7 @@ fn font_cache_speedup() {
     let opts = RenderOptions {
         font_size: 40.0,
         padding: 10.0,
+        background_color: ratex_types::color::Color::WHITE,
         font_dir,
         device_pixel_ratio: 1.0,
     };

--- a/crates/ratex-render/tests/golden_test.rs
+++ b/crates/ratex-render/tests/golden_test.rs
@@ -181,6 +181,7 @@ fn run_golden_suite(
     let render_opts = RenderOptions {
         font_size: 40.0,
         padding: 10.0,
+        background_color: ratex_types::color::Color::WHITE,
         font_dir,
         device_pixel_ratio,
     };
@@ -292,6 +293,7 @@ fn cjk_smoke_non_blank_rendering() {
     let render_opts = RenderOptions {
         font_size: 40.0,
         padding: 10.0,
+        background_color: ratex_types::color::Color::WHITE,
         font_dir,
         device_pixel_ratio: 1.0,
     };

--- a/crates/ratex-render/tests/phase_breakdown.rs
+++ b/crates/ratex-render/tests/phase_breakdown.rs
@@ -30,6 +30,7 @@ fn phase_breakdown() {
     let opts = RenderOptions {
         font_size: 40.0,
         padding: 10.0,
+        background_color: ratex_types::color::Color::WHITE,
         font_dir,
         device_pixel_ratio: 1.0,
     };

--- a/crates/ratex-render/tests/transparent_background.rs
+++ b/crates/ratex-render/tests/transparent_background.rs
@@ -1,0 +1,74 @@
+use std::path::PathBuf;
+
+use ratex_layout::{layout, to_display_list, LayoutOptions};
+use ratex_parser::parser::parse;
+use ratex_render::{render_to_png, RenderOptions};
+use ratex_types::color::Color;
+
+fn project_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn font_dir() -> String {
+    project_root()
+        .join("tools/lexer_compare/node_modules/katex/dist/fonts")
+        .to_string_lossy()
+        .to_string()
+}
+
+fn render_sample(background_color: Color) -> Option<Vec<u8>> {
+    let font_dir = font_dir();
+    if !std::path::Path::new(&font_dir).exists() {
+        return None;
+    }
+
+    let ast = parse("x").expect("parse sample formula");
+    let layout = layout(&ast, &LayoutOptions::default());
+    let display_list = to_display_list(&layout);
+
+    Some(
+        render_to_png(
+            &display_list,
+            &RenderOptions {
+                font_size: 40.0,
+                padding: 8.0,
+                background_color,
+                font_dir,
+                device_pixel_ratio: 1.0,
+            },
+        )
+        .expect("render PNG"),
+    )
+}
+
+fn first_pixel_rgba(png_bytes: &[u8]) -> [u8; 4] {
+    let decoder = png::Decoder::new(std::io::Cursor::new(png_bytes));
+    let mut reader = decoder.read_info().expect("decode PNG info");
+    let mut buf = vec![0u8; reader.output_buffer_size()];
+    let info = reader.next_frame(&mut buf).expect("decode PNG frame");
+    buf.truncate(info.buffer_size());
+    [buf[0], buf[1], buf[2], buf[3]]
+}
+
+#[test]
+fn render_to_png_uses_transparent_background() {
+    let Some(png) = render_sample(Color::new(0.0, 0.0, 0.0, 0.0)) else {
+        eprintln!("SKIP transparent_background: KaTeX font_dir missing");
+        return;
+    };
+    assert_eq!(first_pixel_rgba(&png), [0, 0, 0, 0]);
+}
+
+#[test]
+fn render_to_png_keeps_opaque_background_by_default() {
+    let Some(png) = render_sample(Color::WHITE) else {
+        eprintln!("SKIP transparent_background: KaTeX font_dir missing");
+        return;
+    };
+    assert_eq!(first_pixel_rgba(&png), [255, 255, 255, 255]);
+}

--- a/crates/ratex-types/src/color.rs
+++ b/crates/ratex-types/src/color.rs
@@ -135,6 +135,7 @@ impl Color {
             "brown" => Some(Self::rgb(0.647, 0.165, 0.165)),
             "pink" => Some(Self::rgb(1.0, 0.753, 0.796)),
             "teal" => Some(Self::rgb(0.0, 0.502, 0.502)),
+            "transparent" => Some(Self::new(0.0, 0.0, 0.0, 0.0)),
             _ => None,
         }
     }
@@ -211,6 +212,10 @@ mod tests {
         let aqua = Color::from_name("aqua").unwrap();
         let cyan = Color::from_name("cyan").unwrap();
         assert_eq!(aqua, cyan);
+        assert_eq!(
+            Color::from_name("transparent"),
+            Some(Color::new(0.0, 0.0, 0.0, 0.0))
+        );
         assert!(Color::from_name("lime").is_some());
         assert!(Color::from_name("maroon").is_some());
         assert!(Color::from_name("navy").is_some());


### PR DESCRIPTION
## Summary

- add transparent background support to PNG rendering via `RenderOptions.background_color`
- add CLI `--background-color` support, including `transparent` as a named color
- add regression coverage for transparent and default opaque PNG output

## Testing

- cargo test -p ratex-types color
- cargo test -p ratex-render