### PR TITLE
fix: support htmlStyle rendering

### DIFF
--- a/crates/ratex-layout/src/engine.rs
+++ b/crates/ratex-layout/src/engine.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use ratex_font::{get_char_metrics, get_global_metrics, FontId};
 use ratex_parser::parse_node::{ArrayTag, AtomFamily, Mode, ParseNode};
 use ratex_types::color::Color;
@@ -478,6 +480,8 @@ fn layout_node(node: &ParseNode, options: &LayoutOptions) -> LayoutBox {
         ParseNode::HtmlMathMl { html, .. } => {
             layout_expression(html, options, true)
         }
+
+        ParseNode::Html { attributes, body, .. } => layout_html(attributes, body, options),
 
         ParseNode::MClass { body, .. } => layout_expression(body, options, true),
 
@@ -2695,6 +2699,134 @@ fn layout_sizing(size: u8, body: &[ParseNode], options: &LayoutOptions) -> Layou
             color: options.color,
         }
     }
+}
+
+#[derive(Default)]
+struct HtmlStyle {
+    color: Option<Color>,
+    font_size_scale: Option<f64>,
+    bold: bool,
+    italic: bool,
+    background_color: Option<Color>,
+    underline: bool,
+}
+
+fn layout_html(attributes: &HashMap<String, String>, body: &[ParseNode], options: &LayoutOptions) -> LayoutBox {
+    let style = attributes
+        .get("style")
+        .map(|style| parse_html_style(style))
+        .unwrap_or_default();
+
+    let body_options = match style.color {
+        Some(color) => options.with_color(color),
+        None => options.clone(),
+    };
+    let font_id = match (style.bold, style.italic) {
+        (true, true) => Some(FontId::MainBoldItalic),
+        (true, false) => Some(FontId::MainBold),
+        (false, true) => Some(FontId::MainItalic),
+        (false, false) => None,
+    };
+
+    let body_node = ParseNode::OrdGroup {
+        mode: body.first().map(ParseNode::mode).unwrap_or(Mode::Math),
+        body: body.to_vec(),
+        semisimple: None,
+        loc: None,
+    };
+    let mut lbox = match font_id {
+        Some(font_id) => layout_with_font(&body_node, font_id, &body_options),
+        None => layout_expression(body, &body_options, true),
+    };
+
+    if let Some(scale) = style.font_size_scale {
+        if (scale - 1.0).abs() >= 0.001 {
+            lbox = LayoutBox {
+                width: lbox.width * scale,
+                height: lbox.height * scale,
+                depth: lbox.depth * scale,
+                content: BoxContent::Scaled {
+                    body: Box::new(lbox),
+                    child_scale: scale,
+                },
+                color: body_options.color,
+            };
+        }
+    }
+
+    if let Some(background_color) = style.background_color {
+        lbox = LayoutBox {
+            width: lbox.width,
+            height: lbox.height,
+            depth: lbox.depth,
+            content: BoxContent::Framed {
+                body: Box::new(lbox),
+                padding: 0.0,
+                border_thickness: 0.0,
+                has_border: false,
+                bg_color: Some(background_color),
+                border_color: Color::BLACK,
+            },
+            color: body_options.color,
+        };
+    }
+
+    if style.underline {
+        lbox = layout_underline_laid_out(lbox, options, body_options.color);
+    }
+
+    lbox
+}
+
+fn parse_html_style(style: &str) -> HtmlStyle {
+    let mut parsed = HtmlStyle::default();
+    for declaration in style.split(';') {
+        let Some((property, value)) = declaration.split_once(':') else {
+            continue;
+        };
+        let property = property.trim().to_ascii_lowercase();
+        let value = value.trim();
+        match property.as_str() {
+            "color" => parsed.color = Color::parse(value),
+            "font-size" => parsed.font_size_scale = parse_css_font_size(value),
+            "font-weight" => parsed.bold = is_css_bold(value),
+            "font-style" => parsed.italic = is_css_italic(value),
+            "background" | "background-color" => parsed.background_color = Color::parse(value),
+            "text-decoration" | "text-decoration-line" => {
+                parsed.underline = value
+                    .split_whitespace()
+                    .any(|part| part.eq_ignore_ascii_case("underline"));
+            }
+            _ => {}
+        }
+    }
+    parsed
+}
+
+fn parse_css_font_size(value: &str) -> Option<f64> {
+    let value = value.trim().to_ascii_lowercase().replace(' ', "");
+    let parse_number = |s: &str| s.parse::<f64>().ok().filter(|n| n.is_finite() && *n > 0.0);
+    if let Some(px) = value.strip_suffix("px") {
+        parse_number(px).map(|n| n / 16.0)
+    } else if let Some(em) = value.strip_suffix("em").or_else(|| value.strip_suffix("rem")) {
+        parse_number(em)
+    } else if let Some(percent) = value.strip_suffix('%') {
+        parse_number(percent).map(|n| n / 100.0)
+    } else {
+        None
+    }
+}
+
+fn is_css_bold(value: &str) -> bool {
+    let value = value.trim();
+    value.eq_ignore_ascii_case("bold")
+        || value.eq_ignore_ascii_case("bolder")
+        || value.parse::<u16>().is_ok_and(|weight| weight >= 600)
+}
+
+fn is_css_italic(value: &str) -> bool {
+    let value = value.trim();
+    value.eq_ignore_ascii_case("italic") || value.eq_ignore_ascii_case("oblique")
 }
 
 /// Layout \verb and \verb* — verbatim text in typewriter font.

--- a/crates/ratex-layout/tests/layout_vs_katex.rs
+++ b/crates/ratex-layout/tests/layout_vs_katex.rs
@@ -6,8 +6,11 @@
 ///
 /// Tolerance: 0.001em (well within the 0.02em threshold from the plan).
 use ratex_layout::{layout, LayoutOptions};
+use ratex_layout::to_display_list;
 use ratex_parser::parser::parse;
 use ratex_types::MathStyle;
+use ratex_types::color::Color;
+use ratex_types::display_item::DisplayItem;
 
 const TOLERANCE: f64 = 0.002;
 
@@ -40,6 +43,29 @@ fn layout_with_style(input: &str, style: MathStyle) -> ratex_layout::LayoutBox {
 #[test]
 fn single_char_x() {
     check("x", 0.43056, 0.0);
+}
+
+#[test]
+fn htmlstyle_applies_supported_css() {
+    let ast = parse("\\htmlStyle{color: blue; font-size: 20px; font-weight: bold; font-style: italic; background-color: yellow; text-decoration: underline;}{x}").unwrap();
+    let options = LayoutOptions::default();
+    let lbox = layout(&ast, &options);
+    let display = to_display_list(&lbox);
+
+    assert!(display.width > layout(&parse("x").unwrap(), &options).width);
+    assert!(display.items.iter().any(|item| matches!(
+        item,
+        DisplayItem::Rect { color, .. } if *color == Color::from_name("yellow").unwrap()
+    )));
+    assert!(display.items.iter().any(|item| matches!(
+        item,
+        DisplayItem::Line { color, .. } if *color == Color::from_name("blue").unwrap()
+    )));
+    assert!(display.items.iter().any(|item| matches!(
+        item,
+        DisplayItem::GlyphPath { color, font, .. }
+            if *color == Color::from_name("blue").unwrap() && font == "Main-BoldItalic"
+    )));
 }
 
 #[test]

--- a/crates/ratex-parser/src/functions/htmlmathml.rs
+++ b/crates/ratex-parser/src/functions/htmlmathml.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use crate::error::ParseResult;
-use crate::functions::{define_function_full, FunctionContext, FunctionSpec};
+use crate::error::{ParseError, ParseResult};
+use crate::functions::{define_function_full, ArgType, FunctionContext, FunctionSpec};
 use crate::parse_node::ParseNode;
 
 pub fn register(map: &mut HashMap<&'static str, FunctionSpec>) {
@@ -12,6 +12,16 @@ pub fn register(map: &mut HashMap<&'static str, FunctionSpec>) {
         2, 0, None,
         false, true, true, false, false,
         handle_htmlmathml,
+    );
+
+    define_function_full(
+        map,
+        &["\\htmlStyle"],
+        "html",
+        2, 0,
+        Some(vec![ArgType::Raw, ArgType::Original]),
+        false, true, true, false, false,
+        handle_htmlstyle,
     );
 }
 
@@ -27,6 +37,28 @@ fn handle_htmlmathml(
         mode: ctx.parser.mode,
         html,
         mathml,
+        loc: None,
+    })
+}
+
+fn handle_htmlstyle(
+    ctx: &mut FunctionContext,
+    args: Vec<ParseNode>,
+    _opt_args: Vec<Option<ParseNode>>,
+) -> ParseResult<ParseNode> {
+    let mut args = args.into_iter();
+    let style = match args.next() {
+        Some(ParseNode::Raw { string, .. }) => string,
+        _ => return Err(ParseError::msg("Expected raw style for \\htmlStyle")),
+    };
+    let body = ParseNode::ord_argument(args.next().unwrap());
+    let mut attributes = HashMap::new();
+    attributes.insert("style".to_string(), style);
+
+    Ok(ParseNode::Html {
+        mode: ctx.parser.mode,
+        attributes,
+        body,
         loc: None,
     })
 }

--- a/crates/ratex-parser/src/macro_expander.rs
+++ b/crates/ratex-parser/src/macro_expander.rs
@@ -678,7 +678,8 @@ impl<'a> MacroExpander<'a> {
 
         // KaTeX HTML extensions: no-op (only render content, no HTML attributes).
         // Not standard LaTeX; for compatibility we parse and expand to second argument only.
-        for name in &["\\htmlClass", "\\htmlData", "\\htmlId", "\\htmlStyle"] {
+        // \htmlStyle is registered as a real function so the renderer can honor basic CSS.
+        for name in &["\\htmlClass", "\\htmlData", "\\htmlId"] {
             let name = (*name).to_string();
             self.macros.set(
                 name.clone(),

--- a/crates/ratex-parser/src/tests.rs
+++ b/crates/ratex-parser/src/tests.rs
@@ -499,6 +499,19 @@ mod colors_and_sizing {
         assert_eq!(ast.len(), 1);
         assert_eq!(ast[0].type_name(), "underline");
     }
+
+    #[test]
+    fn htmlstyle() {
+        let ast = parse("\\htmlStyle{color: blue; font-size: 20px;}{x^2}").unwrap();
+        assert_eq!(ast.len(), 1);
+        assert_eq!(ast[0].type_name(), "html");
+        if let ParseNode::Html { attributes, body, .. } = &ast[0] {
+            assert_eq!(attributes.get("style").unwrap(), "color: blue; font-size: 20px;");
+            assert!(!body.is_empty());
+        } else {
+            panic!("Expected html node");
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Parse `\htmlStyle{...}{...}` as an HTML-style parse node instead of dropping the style argument.
- Apply a focused CSS subset during layout: color, font size, bold/italic, background, and underline.
- Add parser and layout tests for supported `\htmlStyle` behavior.

Fixes #68

## Tests
- `cargo build --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`