### PR TITLE
Emoji

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/output**
 Cargo.lock
 # Machine-specific Cargo cross-compilation config (use env vars instead)
 /.cargo/

--- a/crates/ratex-pdf/src/fonts.rs
+++ b/crates/ratex-pdf/src/fonts.rs
@@ -373,10 +373,6 @@ fn decode_png_rgba8(data: &[u8]) -> Result<(u32, u32, Vec<u8>), String> {
     let mut dec = png::Decoder::new(std::io::Cursor::new(data));
     dec.set_transformations(png::Transformations::EXPAND);
     let mut reader = dec.read_info().map_err(|e| format!("png: {e}"))?;
-    let bd = reader.info().bit_depth;
-    if bd != png::BitDepth::Eight {
-        return Err(format!("unsupported png bit depth: {bd:?}"));
-    }
     let mut buf = vec![0u8; reader.output_buffer_size()];
     let info = reader
         .next_frame(&mut buf)

--- a/crates/ratex-pdf/src/fonts.rs
+++ b/crates/ratex-pdf/src/fonts.rs
@@ -213,6 +213,9 @@ pub(crate) fn collect_glyph_usage(
             ..
         } = item
         {
+            #[cfg(target_os = "macos")]
+            let glyph_em = ((*scale * body_em) as f32) * 2.0;
+            #[cfg(not(target_os = "macos"))]
             let glyph_em = (*scale * body_em) as f32;
             // Always collect sbix rasters for emoji / dingbat blocks when a color font is loaded,
             // independent of [`resolve_pdf_glyph`] (avoids edge cases where CJK/Main still "claim" a CP).

--- a/crates/ratex-pdf/src/renderer.rs
+++ b/crates/ratex-pdf/src/renderer.rs
@@ -311,7 +311,15 @@ fn emit_emoji_raster(
     asset: &fonts::EmbeddedEmojiImage,
 ) {
     let ppm = f64::from(asset.pixels_per_em.max(1));
-    let s = glyph_em / ppm;
+    let mut s = glyph_em / ppm;
+
+    // Scale emoji to fit 1.0em layout width if it's wider (prevents overflow).
+    let actual_width_em = f64::from(asset.width_px) / ppm;
+    let assumed_width = 1.0;
+    if actual_width_em > 0.01 && actual_width_em > assumed_width * 1.01 {
+        s *= assumed_width / actual_width_em;
+    }
+
     let disp_w = f64::from(asset.width_px) * s;
     let disp_h = f64::from(asset.height_px) * s;
     let top_x = px + f64::from(asset.strike_x) * s;

--- a/crates/ratex-render/src/renderer.rs
+++ b/crates/ratex-render/src/renderer.rs
@@ -625,7 +625,14 @@ fn try_blit_raster_glyph(
         Some(p) => p,
         None => return false,
     };
-    let scale = em / f32::from(img.pixels_per_em.max(1));
+    let ppm = f32::from(img.pixels_per_em.max(1));
+    let mut scale = em / ppm;
+    // Scale emoji to fit 1.0em layout width if it's wider (prevents overflow).
+    let actual_width_em = f32::from(img.width) / ppm;
+    let assumed_width = 1.0;
+    if actual_width_em > 0.01 && actual_width_em > assumed_width * 1.01 {
+        scale *= assumed_width / actual_width_em;
+    }
     let top_x = px + f32::from(img.x) * scale;
     // `ttf-parser` / OpenType: `RasterGlyphImage::{x,y}` are in strike pixels; `y` is the
     // **bottom** edge of the bitmap in y-up coordinates (sbix yOffset to bottom; CBDT normalized
@@ -635,8 +642,7 @@ fn try_blit_raster_glyph(
     // ink centroid near 0.5em above baseline. Binary/relation glyphs (+, =) are centered on the
     // math axis (~0.25em). Nudge the bitmap so its vertical center matches the axis — matches
     // mixed `\text{emoji} … formula` rows without changing layout baselines.
-    let ppem = f32::from(img.pixels_per_em.max(1));
-    let center_strike = (f32::from(img.y) + f32::from(img.height) / 2.0) / ppem;
+    let center_strike = (f32::from(img.y) + f32::from(img.height) / 2.0) / ppm;
     let axis = ratex_font::get_global_metrics(0).axis_height as f32;
     top_y += (center_strike - axis) * em;
     let paint = PixmapPaint {

--- a/crates/ratex-svg/src/standalone.rs
+++ b/crates/ratex-svg/src/standalone.rs
@@ -108,13 +108,19 @@ fn try_emoji_png_data_url(px: f32, py: f32, em: f32, ch: char) -> Option<Standal
     let request_em = em;
 
     let strike = ratex_unicode_font::emoji_png_raster_for_char(ch, request_em)?;
-    let scale = em / f32::from(strike.pixels_per_em.max(1));
+    let ppm = f32::from(strike.pixels_per_em.max(1));
+    let mut scale = em / ppm;
+    // Scale emoji to fit 1.0em layout width if it's wider (prevents overflow).
+    let actual_width_em = f32::from(strike.width) / ppm;
+    let assumed_width = 1.0;
+    if actual_width_em > 0.01 && actual_width_em > assumed_width * 1.01 {
+        scale *= assumed_width / actual_width_em;
+    }
     let x = px + f32::from(strike.x) * scale;
     // Match `ratex-render::try_blit_raster_glyph`: `y` is the bitmap bottom in y-up strike space;
     // then nudge so the strike's vertical center aligns with the math axis (mixed `\text` + math).
     let mut y = py - (f32::from(strike.y) + f32::from(strike.height)) * scale;
-    let ppem = f32::from(strike.pixels_per_em.max(1));
-    let center_strike = (f32::from(strike.y) + f32::from(strike.height) / 2.0) / ppem;
+    let center_strike = (f32::from(strike.y) + f32::from(strike.height) / 2.0) / ppm;
     let axis = ratex_font::get_global_metrics(0).axis_height as f32;
     y += (center_strike - axis) * em;
     let w = f32::from(strike.width) * scale;

--- a/crates/ratex-svg/src/standalone.rs
+++ b/crates/ratex-svg/src/standalone.rs
@@ -102,7 +102,12 @@ pub(crate) fn standalone_glyph(
 fn try_emoji_png_data_url(px: f32, py: f32, em: f32, ch: char) -> Option<StandaloneGlyph> {
     use base64::{engine::general_purpose::STANDARD, Engine as _};
 
-    let strike = ratex_unicode_font::emoji_png_raster_for_char(ch, em)?;
+    #[cfg(target_os = "macos")]
+    let request_em = em * 2.0;
+    #[cfg(not(target_os = "macos"))]
+    let request_em = em;
+
+    let strike = ratex_unicode_font::emoji_png_raster_for_char(ch, request_em)?;
     let scale = em / f32::from(strike.pixels_per_em.max(1));
     let x = px + f32::from(strike.x) * scale;
     // Match `ratex-render::try_blit_raster_glyph`: `y` is the bitmap bottom in y-up strike space;

--- a/crates/ratex-unicode-font/src/lib.rs
+++ b/crates/ratex-unicode-font/src/lib.rs
@@ -270,25 +270,6 @@ fn is_likely_color_bitmap_emoji_face(face: &fontdb::FaceInfo) -> bool {
 
 fn discover_emoji_font() -> Option<(Arc<Vec<u8>>, u32)> {
     let mut db = fontdb::Database::new();
-
-    // Prefer explicit paths so `.ttc` collections (e.g. Apple Color Emoji) are loaded reliably.
-    #[cfg(target_os = "macos")]
-    {
-        let _ = db.load_font_file(std::path::Path::new(
-            "/System/Library/Fonts/Apple Color Emoji.ttc",
-        ));
-    }
-    #[cfg(target_os = "linux")]
-    {
-        let _ = db.load_font_file(std::path::Path::new(
-            "/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf",
-        ));
-    }
-    #[cfg(target_os = "windows")]
-    {
-        let _ = db.load_font_file(std::path::Path::new(r"C:\Windows\Fonts\seguiemj.ttf"));
-    }
-
     db.load_system_fonts();
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
Add EmojiOutlineScaler for improved emoji (for pdf, svg, Mac)
Normalize wide emoji raster sizing in renderers ( for Noto Color Emoji, ubuntu)
Remove PNG bit depth check in decode_png_rgba8 (for Twemoji, ubuntu)