### PR TITLE
improves font fallback and variable-font consistency across RaTeX renderers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,9 +195,9 @@ The `ratex-pdf` crate writes one `.pdf` per non-empty line from stdin. Options i
 
 By default RaTeX bundles only KaTeX fonts (19 faces for math symbols). Characters outside the KaTeX glyph set — CJK ideographs, emoji, Hangul, etc. — are rendered via a system Unicode font discovered automatically:
 
-1. **`RATEX_UNICODE_FONT`** env var — explicit path to any `.ttf`/`.otf`
-2. **Hard-coded system paths** — macOS (e.g. `/Library/Fonts/Supplemental/Arial Unicode.ttf`, `/System/Library/Fonts/Supplemental/Arial Unicode.ttf`), Linux (`/usr/share/fonts/…`), Windows (`C:\Windows\Fonts\…`)
-3. **fontdb system query** — SansSerif scan, then brute-force
+1. **`RATEX_UNICODE_FONT`** env var — path to any `.ttf`/`.otf`/`.ttc`, with optional `#index` or `#FamilyName` selector for TTC collections (e.g. `NotoSansCJK.ttc#Noto Sans CJK SC`)
+2. **Hard-coded system paths** — Linux (`/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc`), macOS (`/Library/Fonts/Arial Unicode.ttf`, `/System/Library/Fonts/Supplemental/Arial Unicode.ttf`), Windows (`C:\Windows\Fonts\NotoSansSC-VF.ttf`, `C:\Windows\Fonts\msyh.ttc`)
+3. **fontdb system query** — well-known broad-coverage families (Arial Unicode MS, Noto Sans CJK SC, PingFang SC, …), then SansSerif fallback
 
 ```bash
 # Explicit font path (recommended for CI / server environments)

--- a/README.md
+++ b/README.md
@@ -197,18 +197,18 @@ By default RaTeX bundles only KaTeX fonts (19 faces for math symbols). Character
 
 1. **`RATEX_UNICODE_FONT`** env var — path to any `.ttf`/`.otf`/`.ttc`, with optional `#index` or `#FamilyName` selector for TTC collections (e.g. `NotoSansCJK.ttc#Noto Sans CJK SC`)
 2. **Hard-coded system paths** — Linux (`/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc`), macOS (`/Library/Fonts/Arial Unicode.ttf`, `/System/Library/Fonts/Supplemental/Arial Unicode.ttf`), Windows (`C:\Windows\Fonts\NotoSansSC-VF.ttf`, `C:\Windows\Fonts\msyh.ttc`)
-3. **fontdb system query** — well-known broad-coverage families (Arial Unicode MS, Noto Sans CJK SC, PingFang SC, …), then SansSerif fallback
+3. **Locale-aware system discovery** — `system-fonts` resolves prioritized Sans candidates for the current system locale / region, including TTC family selection when needed
 
 ```bash
 # Explicit font path (recommended for CI / server environments)
 RATEX_UNICODE_FONT=/path/to/NotoSansSC-Regular.ttf \
   echo '\text{你好世界}' | cargo run --release -p ratex-render
 
-# Auto-discovery finds Arial Unicode on macOS, DejaVu Sans on Linux, etc.
+# Auto-discovery probes built-in paths first, then locale-aware system Sans fallbacks.
 echo '\text{你好世界}' | cargo run --release -p ratex-render
 ```
 
-All three renderers (PNG, SVG, PDF) use the same discovery crate (`ratex-unicode-font`), so once a font is found the output is consistent across all formats. For PNG and standalone SVG, glyph outlines are embedded as paths. For PDF, the detected CJK glyphs are subsetted and embedded as a CIDFontType2 font.
+All three renderers (PNG, SVG, PDF) use the same discovery crate (`ratex-unicode-font`), so once a font is found the output is consistent across all formats. For variable fonts, RaTeX prefers the Regular `wght=400` instance when that axis is available so outline extraction, metrics, and PDF subsetting stay aligned. For PNG and standalone SVG, glyph outlines are embedded as paths. For PDF, the detected CJK glyphs are subsetted and embedded as a CIDFontType2 font.
 
 ### Browser (WASM)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -198,16 +198,16 @@ echo '\ce{H2SO4 + 2NaOH -> Na2SO4 + 2H2O}' | \
 
 默认 RaTeX 只捆绑 KaTeX 字体（19 种数学符号字形）。KaTeX 字形集之外的字符——CJK 表意文字、emoji、谚文等——通过系统 Unicode 字体自动发现并渲染：
 
-1. **`RATEX_UNICODE_FONT`** 环境变量：指定任意 `.ttf`/`.otf` 路径
-2. **硬编码系统路径**：macOS（例如 `/Library/Fonts/Supplemental/Arial Unicode.ttf`、`/System/Library/Fonts/Supplemental/Arial Unicode.ttf`）、Linux（`/usr/share/fonts/…`）、Windows（`C:\Windows\Fonts\…`）
-3. **fontdb 系统查询**：优先 SansSerif，最后暴力扫描
+1. **`RATEX_UNICODE_FONT`** 环境变量：指定任意 `.ttf`/`.otf`/`.ttc` 路径，TTC 集合可附加 `#index` 或 `#字体族名` 选择器（例如 `NotoSansCJK.ttc#Noto Sans CJK SC`）
+2. **硬编码系统路径**：Linux（`/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc`）、macOS（`/Library/Fonts/Arial Unicode.ttf`、`/System/Library/Fonts/Supplemental/Arial Unicode.ttf`）、Windows（`C:\Windows\Fonts\NotoSansSC-VF.ttf`、`C:\Windows\Fonts\msyh.ttc`）
+3. **fontdb 系统查询**：优先宽覆盖字体族（Arial Unicode MS、Noto Sans CJK SC、PingFang SC 等），最后回退到 SansSerif
 
 ```bash
 # 显式指定字体路径（推荐用于 CI / 服务器环境）
 RATEX_UNICODE_FONT=/path/to/NotoSansSC-Regular.ttf \
   echo '\text{你好世界}' | cargo run --release -p ratex-render
 
-# 自动发现：macOS 找到 Arial Unicode，Linux 找到 DejaVu Sans，等等
+# 自动发现：macOS 找到 Arial Unicode，Linux 找到 NotoSansCJK，等等
 echo '\text{你好世界}' | cargo run --release -p ratex-render
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -200,18 +200,18 @@ echo '\ce{H2SO4 + 2NaOH -> Na2SO4 + 2H2O}' | \
 
 1. **`RATEX_UNICODE_FONT`** 环境变量：指定任意 `.ttf`/`.otf`/`.ttc` 路径，TTC 集合可附加 `#index` 或 `#字体族名` 选择器（例如 `NotoSansCJK.ttc#Noto Sans CJK SC`）
 2. **硬编码系统路径**：Linux（`/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc`）、macOS（`/Library/Fonts/Arial Unicode.ttf`、`/System/Library/Fonts/Supplemental/Arial Unicode.ttf`）、Windows（`C:\Windows\Fonts\NotoSansSC-VF.ttf`、`C:\Windows\Fonts\msyh.ttc`）
-3. **fontdb 系统查询**：优先宽覆盖字体族（Arial Unicode MS、Noto Sans CJK SC、PingFang SC 等），最后回退到 SansSerif
+3. **基于 locale 的系统字体发现**：使用 `system-fonts` 按当前系统语言 / 区域优先解析 Sans 候选，必要时可自动选择 TTC 中对应字体族
 
 ```bash
 # 显式指定字体路径（推荐用于 CI / 服务器环境）
 RATEX_UNICODE_FONT=/path/to/NotoSansSC-Regular.ttf \
   echo '\text{你好世界}' | cargo run --release -p ratex-render
 
-# 自动发现：macOS 找到 Arial Unicode，Linux 找到 NotoSansCJK，等等
+# 自动发现：先探测内置路径，再按当前系统 locale 选择 Sans 回退字体
 echo '\text{你好世界}' | cargo run --release -p ratex-render
 ```
 
-三个渲染器（PNG、SVG、PDF）使用同一个发现 crate（`ratex-unicode-font`），字体找到后各格式输出一致。PNG 和自包含 SVG 将字形轮廓嵌入为路径；PDF 将检测到的 CJK 字形子集化并作为 CIDFontType2 字体嵌入。
+三个渲染器（PNG、SVG、PDF）使用同一个发现 crate（`ratex-unicode-font`），字体找到后各格式输出一致。对于 variable font，如果存在 `wght` 轴，RaTeX 会优先使用 Regular `wght=400` 实例，以保证轮廓提取、字宽度量和 PDF 子集化行为一致。PNG 和自包含 SVG 将字形轮廓嵌入为路径；PDF 将检测到的 CJK 字形子集化并作为 CIDFontType2 字体嵌入。
 
 ### 在浏览器中使用（WASM）
 

--- a/crates/ratex-font-loader/src/outline_cache.rs
+++ b/crates/ratex-font-loader/src/outline_cache.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, RwLock};
 
-use ab_glyph::{Font, FontRef, GlyphId, OutlineCurve};
+use ab_glyph::{Font, FontRef, GlyphId, OutlineCurve, VariableFont};
 use ratex_font::FontId;
 
 type OutlineData = Arc<[OutlineCurve]>;
@@ -20,6 +20,8 @@ static OUTLINE_CACHE: LazyLock<RwLock<HashMap<(FontId, GlyphId), OutlineData>>> 
 ///
 /// Position and scale are **not** applied — callers must transform the curves
 /// with their own `px`, `py`, and `em` values before rasterising or serializing.
+///
+/// For variable fonts, sets `wght=400` (Regular) if the axis exists and supports it.
 pub fn get_or_compute_outline(
     font_id: FontId,
     font: &FontRef<'_>,
@@ -36,7 +38,24 @@ pub fn get_or_compute_outline(
     }
 
     // Slow path: compute outline + write-lock
-    let outline = font.outline(glyph_id)?;
+    // For variable fonts, set wght=400 if available
+    let mut font_instance = font.clone();
+    let axes = font_instance.variations();
+    if !axes.is_empty() {
+        for axis in axes {
+            if &axis.tag == b"wght" {
+                let target_weight = if axis.min_value <= 400.0 && 400.0 <= axis.max_value {
+                    400.0
+                } else {
+                    axis.default_value
+                };
+                font_instance.set_variation(b"wght", target_weight);
+                break;
+            }
+        }
+    }
+
+    let outline = font_instance.outline(glyph_id)?;
     let curves: Arc<[OutlineCurve]> = outline.curves.into();
 
     let mut cache = OUTLINE_CACHE.write().unwrap();

--- a/crates/ratex-pdf/src/fonts.rs
+++ b/crates/ratex-pdf/src/fonts.rs
@@ -6,11 +6,11 @@ use ab_glyph::Font as _;
 use pdf_writer::{types::*, Filter, Finish, Name, Pdf, Ref, Str};
 use ratex_font::FontId;
 use ratex_font_loader::FontSet;
-use skrifa::instance::{LocationRef, Size};
+use skrifa::instance::{Location, Size};
 use skrifa::outline::{DrawSettings, OutlinePen};
 use skrifa::raw::FontRef as SfFontRef;
 use skrifa::raw::TableProvider;
-use skrifa::{GlyphId, MetadataProvider};
+use skrifa::{GlyphId, MetadataProvider, Tag};
 use subsetter::GlyphRemapper;
 
 /// Loaded TTF bytes keyed by FontId.
@@ -43,6 +43,27 @@ fn skrifa_collection_index(face_id: FontId) -> u32 {
 /// supplementary-plane emoji in `KaTeX_Main-Regular` to a non-zero GID while `ab_glyph` (and our
 /// layout) treat them as absent — that would make [`resolve_pdf_glyph`] stop at `MainRegular` and
 /// never reach [`FontId::EmojiFallback`], so color emoji rasters were never collected or drawn.
+///
+/// If the font has a `wght` variation axis, return the weight to use.
+/// Prefers Regular (400) and falls back to the axis default if 400 is out of range.
+fn variable_weight(font: &SfFontRef) -> Option<f32> {
+    let axes = font.axes();
+    let wght_axis = axes.get_by_tag(Tag::new(b"wght"))?;
+
+    Some(if wght_axis.min_value() <= 400.0 && 400.0 <= wght_axis.max_value() {
+        400.0
+    } else {
+        wght_axis.default_value()
+    })
+}
+
+/// If the font has a `wght` variation axis, return a `Location` targeting the selected weight.
+fn variable_location(font: &SfFontRef) -> Option<Location> {
+    let target_weight = variable_weight(font)?;
+    Some(font.axes().location([("wght", target_weight)]))
+}
+
+/// Always use `ab_glyph` / OpenType cmap so PDF glyph selection stays aligned with layout.
 #[inline]
 fn resolve_glyph_id_for_face(raw_bytes: &[u8], font_id: FontId, char_code: u32) -> Option<u16> {
     resolve_glyph_id_abglyph(raw_bytes, font_id, char_code)
@@ -77,7 +98,9 @@ pub(crate) fn glyph_has_nonempty_outline(raw_bytes: &[u8], face_id: FontId, gid:
         fn close(&mut self) {}
     }
     let mut pen = PenStats::default();
-    let settings = DrawSettings::unhinted(Size::new(16.0), LocationRef::default());
+    // For non-variable fonts, use default Location; for variable fonts, use the computed location.
+    let location = variable_location(&font).unwrap_or_default();
+    let settings = DrawSettings::unhinted(Size::new(16.0), &location);
     glyph.draw(settings, &mut pen).is_ok() && pen.draws > 0
 }
 
@@ -430,15 +453,20 @@ pub(crate) fn embed_fonts(
         }
 
         // Subset the font.
-        let subsetted = subsetter::subset(raw, skrifa_collection_index(usage.font_id), &remapper)
-            .map_err(|e| format!("Subset error for {:?}: {e}", usage.font_id))?;
+        let index = skrifa_collection_index(usage.font_id);
+        let sf = SfFontRef::from_index(raw, index)
+            .map_err(|e| format!("skrifa error: {e}"))?;
+        let subsetted = if let Some(target_weight) = variable_weight(&sf) {
+            let coords = [(subsetter::Tag::new(b"wght"), target_weight)];
+            subsetter::subset_with_variations(raw, index, &coords, &remapper)
+        } else {
+            subsetter::subset(raw, index, &remapper)
+        }.map_err(|e| format!("Subset error for {:?}: {e}", usage.font_id))?;
 
         // Compress the subset.
         let compressed = miniz_oxide::deflate::compress_to_vec_zlib(&subsetted, 6);
 
         // Read font metrics via skrifa.
-        let sf = SfFontRef::from_index(raw, skrifa_collection_index(usage.font_id))
-            .map_err(|e| format!("skrifa error: {e}"))?;
         let upem = sf.head().map_err(|_| "no head table")?.units_per_em() as f32;
         let scale = 1000.0 / upem; // PDF uses 1000 units per em for metrics
 
@@ -462,13 +490,26 @@ pub(crate) fn embed_fonts(
         };
 
         // Glyph widths (in 1000-unit space).
-        let hmtx = sf.hmtx().map_err(|_| "no hmtx table")?;
+        let location = variable_location(&sf);
         let mut widths: Vec<(u16, f32)> = Vec::new();
-        for &old_gid in usage.glyphs.keys() {
-            let new_cid = remapper.get(old_gid).unwrap_or(0);
-            let gid = skrifa::raw::types::GlyphId::new(old_gid as u32);
-            let advance = hmtx.advance(gid).unwrap_or(0) as f32 * scale;
-            widths.push((new_cid, advance));
+        if let Some(ref loc) = location {
+            // Use variation-aware glyph metrics for variable fonts.
+            let glyph_metrics = sf.glyph_metrics(Size::unscaled(), loc);
+            for &old_gid in usage.glyphs.keys() {
+                let new_cid = remapper.get(old_gid).unwrap_or(0);
+                let gid = skrifa::raw::types::GlyphId::new(old_gid as u32);
+                let advance = glyph_metrics.advance_width(gid).unwrap_or(0.0) * scale;
+                widths.push((new_cid, advance));
+            }
+        } else {
+            // Static font: read directly from hmtx table.
+            let hmtx = sf.hmtx().map_err(|_| "no hmtx table")?;
+            for &old_gid in usage.glyphs.keys() {
+                let new_cid = remapper.get(old_gid).unwrap_or(0);
+                let gid = skrifa::raw::types::GlyphId::new(old_gid as u32);
+                let advance = hmtx.advance(gid).unwrap_or(0) as f32 * scale;
+                widths.push((new_cid, advance));
+            }
         }
         widths.sort_by_key(|(cid, _)| *cid);
 

--- a/crates/ratex-unicode-font/Cargo.toml
+++ b/crates/ratex-unicode-font/Cargo.toml
@@ -10,4 +10,5 @@ description = "System Unicode font discovery for RaTeX fallback rendering"
 
 [dependencies]
 fontdb = { version = "0.23", features = ["std"] }
+system-fonts = "0.1"
 ttf-parser = "0.25"

--- a/crates/ratex-unicode-font/src/lib.rs
+++ b/crates/ratex-unicode-font/src/lib.rs
@@ -17,6 +17,7 @@ mod emoji_raster;
 pub use emoji_raster::{emoji_png_raster_for_char, emoji_raster_for_char, EmojiRasterStrike};
 
 use std::sync::{Arc, OnceLock};
+use system_fonts::{find_for_system_locale, FontStyle, FoundFontSource};
 
 /// `(full font file bytes, face index within TTC or 0 for single-font / unknown collection face)`.
 static UNICODE_FONT: OnceLock<Option<(Arc<Vec<u8>>, u32)>> = OnceLock::new();
@@ -119,7 +120,8 @@ fn load_unicode_fallback_font() -> Option<(Arc<Vec<u8>>, u32)> {
     discover_system_font()
 }
 
-/// Discover a font from system paths and fontdb (does NOT check `RATEX_UNICODE_FONT`).
+/// Discover a font from system paths and locale-aware system-fonts presets (does NOT check
+/// `RATEX_UNICODE_FONT`).
 ///
 /// Prioritizes fonts with broad Unicode coverage (emoji, symbols, CJK) so that the fallback
 /// is useful even when the primary font (e.g. a narrow Korean font) lacks many glyphs.
@@ -139,85 +141,34 @@ fn discover_system_font() -> Option<(Arc<Vec<u8>>, u32)> {
 
     for &spec in candidates {
         if let Some(font) = load_font_spec(spec) {
-            eprintln!("[ratex-unicode-font] found system font: {}", spec);
+            eprintln!("[ratex-unicode-font] found via builtin path: {}", spec);
             return Some(font);
         }
     }
 
-    // 2. fontdb — search for well-known broad-coverage families first.
-    let mut db = fontdb::Database::new();
-    db.load_system_fonts();
-
-    #[cfg(target_os = "macos")]
-    let fallback_families: &[&str] = &[
-        "Arial Unicode MS",
-        "Noto Sans CJK SC",
-        "Noto Sans SC",
-        "PingFang SC",
-        "Arial",
-        "Noto Sans",
-    ];
-    #[cfg(target_os = "linux")]
-    let fallback_families: &[&str] = &[
-        "Arial Unicode MS",
-        "Noto Sans CJK SC",
-        "Noto Sans SC",
-        "DejaVu Sans",
-        "Arial",
-        "Noto Sans",
-    ];
-    #[cfg(target_os = "windows")]
-    let fallback_families: &[&str] = &[
-        "Arial Unicode MS",
-        "Noto Sans CJK SC",
-        "Noto Sans SC",
-        "Microsoft YaHei",
-        "Arial",
-        "Noto Sans",
-    ];
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    let fallback_families: &[&str] = &[];
-
-    for family in fallback_families {
-        let query = fontdb::Query {
-            families: &[fontdb::Family::Name(family)],
-            weight: fontdb::Weight::NORMAL,
-            stretch: fontdb::Stretch::Normal,
-            style: fontdb::Style::Normal,
+    // 2. Locale-aware prioritized candidates from system-fonts.
+    let (_locale, region, fonts) = find_for_system_locale(FontStyle::Sans);
+    for found in fonts {
+        let FoundFontSource::Path(path) = found.source else {
+            continue;
         };
-        if let Some(id) = db.query(&query) {
-            if let Some(pair) = db
-                .with_face_data(id, |data, index| {
-                    is_sfnt_container(data).then(|| (data.to_vec(), index))
-                })
-                .flatten()
-            {
-                let bytes = Arc::new(pair.0);
-                eprintln!(
-                    "[ratex-unicode-font] found via fontdb: {} (face index {})",
-                    family, pair.1
-                );
-                return Some((bytes, pair.1));
-            }
-        }
-    }
 
-    // 3. Generic SansSerif query.
-    let query = fontdb::Query {
-        families: &[fontdb::Family::SansSerif],
-        weight: fontdb::Weight::NORMAL,
-        stretch: fontdb::Stretch::Normal,
-        style: fontdb::Style::Normal,
-    };
-    if let Some(id) = db.query(&query) {
-        if let Some(pair) = db
-            .with_face_data(id, |data, index| {
-                is_sfnt_container(data).then(|| (data.to_vec(), index))
-            })
-            .flatten()
+        let spec = if path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("ttc"))
         {
-            let bytes = Arc::new(pair.0);
-            return Some((bytes, pair.1));
+            format!("{}#{}", path.display(), found.family)
+        } else {
+            path.display().to_string()
+        };
+
+        if let Some(font) = load_font_spec(&spec) {
+            eprintln!(
+                "[ratex-unicode-font] found via system-fonts: {} ({region:?})",
+                spec
+            );
+            return Some(font);
         }
     }
 

--- a/crates/ratex-unicode-font/src/lib.rs
+++ b/crates/ratex-unicode-font/src/lib.rs
@@ -93,10 +93,6 @@ pub fn emoji_font_face_index() -> Option<u32> {
         .map(|(_, i)| *i)
 }
 
-fn is_valid_font(bytes: &[u8]) -> bool {
-    is_sfnt_single_font(bytes)
-}
-
 /// TrueType / OpenType **single** font (not `.ttc`). For collections see [`is_sfnt_container`].
 fn is_sfnt_single_font(bytes: &[u8]) -> bool {
     bytes.len() >= 4
@@ -112,13 +108,10 @@ fn is_sfnt_container(bytes: &[u8]) -> bool {
 
 fn load_unicode_fallback_font() -> Option<(Arc<Vec<u8>>, u32)> {
     // 1. User-specified font via RATEX_UNICODE_FONT
-    if let Ok(p) = std::env::var("RATEX_UNICODE_FONT") {
-        if let Ok(bytes) = std::fs::read(std::path::Path::new(&p)) {
-            if is_sfnt_container(&bytes) {
-                // Default face 0; multi-face `.ttc` can be targeted via fontdb discovery without env.
-                let bytes = Arc::new(bytes);
-                return Some((bytes, 0));
-            }
+    if let Ok(spec) = std::env::var("RATEX_UNICODE_FONT") {
+        if let Some(font) = load_font_spec(&spec) {
+            eprintln!("[ratex-unicode-font] loaded from RATEX_UNICODE_FONT: {}", spec);
+            return Some(font);
         }
     }
 
@@ -135,27 +128,19 @@ fn discover_system_font() -> Option<(Arc<Vec<u8>>, u32)> {
     #[rustfmt::skip]
     let candidates: &[&str] = &[
         // Linux
-        "/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf",
-        "/usr/share/fonts/opentype/noto/NotoSans-Regular.otf",
-        "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.otf",
-        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
-        "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
-        // macOS — broad-coverage fonts first
+        "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc#Noto Sans CJK SC",
+        // macOS
+        "/Library/Fonts/Arial Unicode.ttf",
         "/System/Library/Fonts/Supplemental/Arial Unicode.ttf",
-        "/System/Library/Fonts/Supplemental/Apple Symbols.ttf",
-        "/Library/Fonts/Supplemental/Arial Unicode.ttf",
-        "/Library/Fonts/Arial.ttf",
         // Windows
-        "C:\\Windows\\Fonts\\segoeui.ttf",
-        "C:\\Windows\\Fonts\\arial.ttf",
+        "C:\\Windows\\Fonts\\NotoSansSC-VF.ttf",
+        "C:\\Windows\\Fonts\\msyh.ttc#Microsoft YaHei",
     ];
 
-    for path in candidates {
-        if let Ok(bytes) = std::fs::read(std::path::Path::new(path)) {
-            if is_valid_font(&bytes) {
-                let bytes = Arc::new(bytes);
-                return Some((bytes, 0));
-            }
+    for &spec in candidates {
+        if let Some(font) = load_font_spec(spec) {
+            eprintln!("[ratex-unicode-font] found system font: {}", spec);
+            return Some(font);
         }
     }
 
@@ -165,30 +150,30 @@ fn discover_system_font() -> Option<(Arc<Vec<u8>>, u32)> {
 
     #[cfg(target_os = "macos")]
     let fallback_families: &[&str] = &[
-        // Broad text coverage first — emoji-only faces lack most CJK ideographs (issue: AppleGothic + 氧/碳).
         "Arial Unicode MS",
+        "Noto Sans CJK SC",
+        "Noto Sans SC",
         "PingFang SC",
-        "PingFang TC",
-        "Hiragino Sans",
-        "Apple Symbols",
-        "Apple Color Emoji",
+        "Arial",
+        "Noto Sans",
     ];
     #[cfg(target_os = "linux")]
     let fallback_families: &[&str] = &[
+        "Arial Unicode MS",
         "Noto Sans CJK SC",
-        "Noto Sans CJK TC",
-        "Noto Sans CJK JP",
-        "Noto Sans Symbols",
+        "Noto Sans SC",
         "DejaVu Sans",
-        "Liberation Sans",
-        "Noto Color Emoji",
+        "Arial",
+        "Noto Sans",
     ];
     #[cfg(target_os = "windows")]
     let fallback_families: &[&str] = &[
         "Arial Unicode MS",
+        "Noto Sans CJK SC",
+        "Noto Sans SC",
         "Microsoft YaHei",
-        "Segoe UI Symbol",
-        "Segoe UI Emoji",
+        "Arial",
+        "Noto Sans",
     ];
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     let fallback_families: &[&str] = &[];
@@ -208,6 +193,10 @@ fn discover_system_font() -> Option<(Arc<Vec<u8>>, u32)> {
                 .flatten()
             {
                 let bytes = Arc::new(pair.0);
+                eprintln!(
+                    "[ratex-unicode-font] found via fontdb: {} (face index {})",
+                    family, pair.1
+                );
                 return Some((bytes, pair.1));
             }
         }
@@ -232,40 +221,64 @@ fn discover_system_font() -> Option<(Arc<Vec<u8>>, u32)> {
         }
     }
 
-    // 4. Brute-force fontdb scan (last resort): deterministic order + skip color-emoji bitmap faces
-    // (they lack CJK coverage and vary widely across installs).
-    let mut faces: Vec<&fontdb::FaceInfo> = db.faces().collect();
-    faces.retain(|f| !is_likely_color_bitmap_emoji_face(f));
-    faces.sort_by(|a, b| {
-        a.post_script_name
-            .cmp(&b.post_script_name)
-            .then_with(|| a.index.cmp(&b.index))
-            .then_with(|| a.id.cmp(&b.id))
-    });
-    for face in faces {
-        if let Some(pair) = db
-            .with_face_data(face.id, |data, index| {
-                is_sfnt_container(data).then(|| (data.to_vec(), index))
-            })
-            .flatten()
-        {
-            let bytes = Arc::new(pair.0);
-            return Some((bytes, pair.1));
-        }
-    }
-
+    eprintln!("[ratex-unicode-font] no Unicode font found");
     None
 }
 
-/// Color / bitmap emoji families are poor universal text fallbacks and ordering differs by OS.
-#[inline]
-fn is_likely_color_bitmap_emoji_face(face: &fontdb::FaceInfo) -> bool {
-    let scan = |s: &str| {
-        let l = s.to_ascii_lowercase();
-        (l.contains("color") && l.contains("emoji")) || l.ends_with(" ui emoji")
+enum FaceSelector<'a> {
+    Index(u32),
+    Family(&'a str),
+}
+
+/// Parse and load a font spec: `path` or `path#index` or `path#FamilyName`.
+fn load_font_spec(spec: &str) -> Option<(Arc<Vec<u8>>, u32)> {
+    let (path, selector) = if let Some((p, suffix)) = spec.rsplit_once('#') {
+        if p.is_empty() || suffix.is_empty() {
+            (spec, None)
+        } else if let Ok(index) = suffix.parse::<u32>() {
+            (p, Some(FaceSelector::Index(index)))
+        } else {
+            (p, Some(FaceSelector::Family(suffix)))
+        }
+    } else {
+        (spec, None)
     };
-    scan(face.post_script_name.as_str())
-        || face.families.iter().any(|(name, _)| scan(name.as_str()))
+
+    let bytes = std::fs::read(std::path::Path::new(path)).ok()?;
+    if !is_sfnt_container(&bytes) {
+        return None;
+    }
+
+    let face_index = match selector {
+        None => 0,
+        Some(FaceSelector::Index(idx)) => {
+            let count = ttf_parser::fonts_in_collection(&bytes).unwrap_or(1);
+            if idx >= count {
+                return None;
+            }
+            idx
+        }
+        Some(FaceSelector::Family(family)) => {
+            if is_sfnt_single_font(&bytes) {
+                return None;
+            }
+            find_face_index_by_family(path, family)?
+        }
+    };
+
+    Some((Arc::new(bytes), face_index))
+}
+
+fn find_face_index_by_family(path: &str, family_hint: &str) -> Option<u32> {
+    let mut db = fontdb::Database::new();
+    db.load_font_file(path).ok()?;
+    let face_index = db.faces().find_map(|face| {
+        face.families
+            .iter()
+            .any(|(name, _)| name == family_hint)
+            .then_some(face.index)
+    });
+    face_index
 }
 
 fn discover_emoji_font() -> Option<(Arc<Vec<u8>>, u32)> {
@@ -306,46 +319,55 @@ fn discover_emoji_font() -> Option<(Arc<Vec<u8>>, u32)> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_sfnt_container, is_valid_font};
+    use super::*;
 
     #[test]
-    fn valid_truetype_magic() {
-        assert!(is_valid_font(&[0x00, 0x01, 0x00, 0x00]));
-    }
+    #[cfg(target_os = "macos")]
+    fn test_load_font_spec_macos() {
+        let result = load_font_spec("/Library/Fonts/Arial Unicode.ttf");
+        assert!(result.is_some(), "Should load Arial Unicode.ttf");
+        if let Some((bytes, face_index)) = result {
+            assert!(!bytes.is_empty());
+            assert_eq!(face_index, 0);
+        }
 
-    #[test]
-    fn valid_ttc_magic() {
-        assert!(is_sfnt_container(b"ttcfxxxx"));
-        assert!(!is_valid_font(b"ttcfxxxx"));
-    }
+        let result = load_font_spec("/Library/Fonts/Arial Unicode.ttf#0");
+        assert!(result.is_some(), "Should load Arial Unicode.ttf#0");
+        if let Some((_, face_index)) = result {
+            assert_eq!(face_index, 0);
+        }
 
-    #[test]
-    fn valid_otto_magic() {
-        assert!(is_valid_font(&[0x4F, 0x54, 0x54, 0x4F]));
-    }
+        let result = load_font_spec("/Library/Fonts/Arial Unicode.ttf#1");
+        assert!(result.is_none(), "Should fail for TTF with index > 0");
 
-    #[test]
-    fn valid_apple_truetype_magic() {
-        assert!(is_valid_font(&[0x74, 0x72, 0x75, 0x65]));
-    }
+        let result = load_font_spec("/Library/Fonts/Arial Unicode.ttf#Arial Unicode MS");
+        assert!(result.is_none(), "Should fail for TTF with family selector");
 
-    #[test]
-    fn invalid_empty_slice() {
-        assert!(!is_valid_font(&[]));
-    }
+        let result_family = load_font_spec("/System/Library/Fonts/PingFang.ttc#PingFang SC");
+        assert!(result_family.is_some(), "Should load PingFang.ttc with family name");
 
-    #[test]
-    fn invalid_wrong_magic() {
-        assert!(!is_valid_font(b"ABCD"));
-    }
+        let result_default = load_font_spec("/System/Library/Fonts/PingFang.ttc");
+        assert!(result_default.is_some(), "Should load PingFang.ttc without selector");
+        if let Some((_, face_index)) = result_default {
+            assert_eq!(face_index, 0, "TTC without selector should default to face 0");
+        }
 
-    #[test]
-    fn invalid_woff_magic() {
-        assert!(!is_valid_font(b"wOFF"));
-    }
+        if let Some((_, face_index_family)) = result_family {
+            let result_index =
+                load_font_spec(&format!("/System/Library/Fonts/PingFang.ttc#{}", face_index_family));
+            assert!(result_index.is_some(), "Should load PingFang.ttc with index");
+            if let Some((_, face_index_idx)) = result_index {
+                assert_eq!(
+                    face_index_family, face_index_idx,
+                    "Family and index should resolve to same face"
+                );
+            }
+        }
 
-    #[test]
-    fn invalid_too_short() {
-        assert!(!is_valid_font(&[0x00, 0x01, 0x00]));
+        let result = load_font_spec("/System/Library/Fonts/PingFang.ttc#0");
+        assert!(result.is_some(), "Should load PingFang.ttc#0");
+
+        let result = load_font_spec("/System/Library/Fonts/PingFang.ttc#NonExistent Font");
+        assert!(result.is_none(), "Should fail for non-existent family name");
     }
 }


### PR DESCRIPTION
  ### Changes

  - unify variable font weight handling across SVG, render, and PDF
    - use `wght=400` when supported
    - keep glyph outline extraction, glyph metrics, and PDF subsetting aligned for variable fonts

  - improve Unicode fallback font loading
    - support TTC face selection via `RATEX_UNICODE_FONT=path#index` and `RATEX_UNICODE_FONT=path#FamilyName`
    - broaden built-in system font candidates to prefer wide Unicode coverage fonts such as Noto Sans CJK, Arial Unicode, and Microsoft YaHei
    - simplify font validation by consistently treating single-font and TTC containers via `is_sfnt_container`

  - switch system fallback discovery to locale-aware lookup
    - use `system-fonts` to resolve Sans fallback candidates based on system locale/region
    - preserve built-in path probing as the first fallback layer

  - update documentation
    - refresh English and Chinese README examples for TTC selectors
    - document actual platform font paths and revised fallback behavior

  ### Impact

  - more reliable CJK / Unicode fallback on macOS, Linux, and Windows
  - better TTC support for user-specified fonts
  - more consistent output across PNG, SVG, and PDF when variable fonts are involved