### PR TITLE
fix(windows): plugin builds against current Flutter Windows registrant

### DIFF
--- a/platforms/flutter/windows/CMakeLists.txt
+++ b/platforms/flutter/windows/CMakeLists.txt
@@ -8,6 +8,7 @@ set(PLUGIN_NAME "ratex_flutter_plugin")
 
 list(APPEND PLUGIN_SOURCES
   "ratex_flutter_plugin.cpp"
+  "ratex_flutter_plugin_c_api.cpp"
 )
 
 add_library(${PLUGIN_NAME} SHARED

--- a/platforms/flutter/windows/CMakeLists.txt
+++ b/platforms/flutter/windows/CMakeLists.txt
@@ -18,7 +18,7 @@ apply_standard_settings(${PLUGIN_NAME})
 set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden)
 target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
-target_include_directories(${PLUGIN_NAME} INTERFACE
+target_include_directories(${PLUGIN_NAME} PUBLIC
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
 

--- a/platforms/flutter/windows/include/ratex_flutter/ratex_flutter_plugin_c_api.h
+++ b/platforms/flutter/windows/include/ratex_flutter/ratex_flutter_plugin_c_api.h
@@ -1,0 +1,26 @@
+// C API header for Flutter's auto-generated Windows registrant.
+// Delegates to RatexFlutterPluginRegisterWithRegistrar in ratex_flutter_plugin.h.
+
+#ifndef FLUTTER_PLUGIN_RATEX_FLUTTER_PLUGIN_C_API_H_
+#define FLUTTER_PLUGIN_RATEX_FLUTTER_PLUGIN_C_API_H_
+
+#include <flutter_plugin_registrar.h>
+
+#ifdef FLUTTER_PLUGIN_IMPL
+#define FLUTTER_PLUGIN_EXPORT __declspec(dllexport)
+#else
+#define FLUTTER_PLUGIN_EXPORT __declspec(dllimport)
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+FLUTTER_PLUGIN_EXPORT void RatexFlutterPluginCApiRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif  // FLUTTER_PLUGIN_RATEX_FLUTTER_PLUGIN_C_API_H_

--- a/platforms/flutter/windows/ratex_flutter_plugin_c_api.cpp
+++ b/platforms/flutter/windows/ratex_flutter_plugin_c_api.cpp
@@ -1,0 +1,11 @@
+// C API entry point for Flutter's auto-generated Windows registrant.
+// Delegates to the legacy RatexFlutterPluginRegisterWithRegistrar so both
+// the current ("*CApi*") and legacy name variants resolve to the same body.
+
+#include "include/ratex_flutter/ratex_flutter_plugin_c_api.h"
+#include "include/ratex_flutter/ratex_flutter_plugin.h"
+
+void RatexFlutterPluginCApiRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  RatexFlutterPluginRegisterWithRegistrar(registrar);
+}


### PR DESCRIPTION
## Summary

Two patches that together make `ratex_flutter`'s Windows plugin build out-of-the-box against current Flutter (verified against Flutter 3.41.9 stable / Dart 3.11.5 on Windows 10).

### Bug 1 — plugin's own .cpp can't find its own header

`windows/CMakeLists.txt` declares `target_include_directories(... INTERFACE ...)`. INTERFACE exposes the dir only to consumers — the plugin's own `ratex_flutter_plugin.cpp` cannot resolve `#include "ratex_flutter/ratex_flutter_plugin.h"`. Fix: widen scope to PUBLIC (strict CMake superset; consumers see no behavioural change).

### Bug 2 — missing C API registrant

Flutter's auto-generated `generated_plugin_registrant.cc` (since Flutter ~2.10) includes `<ratex_flutter/ratex_flutter_plugin_c_api.h>` and calls `RatexFlutterPluginCApiRegisterWithRegistrar(...)`. The plugin only shipped the legacy `RatexFlutterPluginRegisterWithRegistrar`. Fix: add the C API header + a one-line shim that delegates to the legacy entry, so both name variants resolve to the same body.

## Reproduction

```bash
flutter create --platforms=windows test_app && cd test_app
flutter pub add ratex_flutter
flutter build windows --debug
```

Before this PR fails with:
```
ratex_flutter_plugin.cpp(7,10): error C1083: Cannot open include file:
  'ratex_flutter/ratex_flutter_plugin.h': No such file or directory
```
After commit 1 alone, build progresses further then fails at:
```
generated_plugin_registrant.cc(10,10): error C1083: Cannot open include
  file: 'ratex_flutter/ratex_flutter_plugin_c_api.h': No such file or directory
```
After commit 2 the build succeeds.

## Backwards compatibility

- INTERFACE → PUBLIC: zero impact on consumers (PUBLIC is a strict CMake superset).
- Legacy `RatexFlutterPluginRegisterWithRegistrar` entry remains in `ratex_flutter_plugin.cpp` unchanged. Any consumer still using the legacy name (older Flutter, manual registrant) sees no change — the new entry just calls into it.

## Test plan

- [x] `flutter build windows --debug` succeeds on a fresh `flutter create` consumer (Flutter 3.41.9 stable / Win10)
- [x] `flutter build apk --debug` still succeeds (Android path untouched)
- [x] `flutter build linux --debug` not regressed (Linux CMakeLists untouched)
- [ ] iOS / macOS — please verify in CI (those platform dirs untouched)

## Versioning / CHANGELOG

Left to the maintainer's release process. No version bump or CHANGELOG entry in this PR.