### PR TITLE
feat(parser): add bussproofs prooftree support

### DIFF
--- a/crates/ratex-layout/src/engine.rs
+++ b/crates/ratex-layout/src/engine.rs
@@ -1,13 +1,15 @@
 use std::collections::HashMap;
 
 use ratex_font::{get_char_metrics, get_global_metrics, FontId};
-use ratex_parser::parse_node::{ArrayTag, AtomFamily, Mode, ParseNode};
+use ratex_parser::parse_node::{
+    ArrayTag, AtomFamily, Mode, ParseNode, ProofBranch, ProofLineStyle,
+};
 use ratex_types::color::Color;
 use ratex_types::math_style::MathStyle;
 use ratex_types::path_command::PathCommand;
 
 use crate::hbox::make_hbox;
-use crate::layout_box::{BoxContent, LayoutBox};
+use crate::layout_box::{BoxContent, LayoutBox, PlacedBox, ProofRule};
 use crate::layout_options::LayoutOptions;
 
 use crate::katex_svg::parse_svg_path_data;
@@ -391,6 +393,8 @@ fn layout_node(node: &ParseNode, options: &LayoutOptions) -> LayoutBox {
             label_below,
             ..
         } => layout_cd_arrow(direction, label_above.as_deref(), label_below.as_deref(), 0.0, 0.0, 0.0, options),
+
+        ParseNode::ProofTree { tree, .. } => layout_proof_tree(tree, options),
 
         ParseNode::Sizing { size, body, .. } => layout_sizing(*size, body, options),
 
@@ -4663,6 +4667,181 @@ fn layout_cd(body: &[Vec<ParseNode>], options: &LayoutOptions) -> LayoutBox {
             tags_left: false,
         },
         color: options.color,
+    }
+}
+
+struct ProofTreeLayout {
+    width: f64,
+    height: f64,
+    depth: f64,
+    children: Vec<PlacedBox>,
+    rules: Vec<ProofRule>,
+}
+
+fn layout_proof_tree(tree: &ProofBranch, options: &LayoutOptions) -> LayoutBox {
+    let laid = layout_proof_branch(tree, options);
+    LayoutBox {
+        width: laid.width,
+        height: laid.height,
+        depth: laid.depth,
+        content: BoxContent::ProofTree {
+            children: laid.children,
+            rules: laid.rules,
+        },
+        color: options.color,
+    }
+}
+
+fn layout_proof_branch(tree: &ProofBranch, options: &LayoutOptions) -> ProofTreeLayout {
+    let metrics = options.metrics();
+    let rule_thickness = metrics.default_rule_thickness;
+    let premise_gap = 0.6;
+    let label_gap = 0.25;
+    let vertical_gap = 0.18;
+
+    let conclusion = layout_expression(&tree.conclusion, options, true);
+
+    if tree.premises.is_empty() {
+        let width = conclusion.width;
+        let height = conclusion.height;
+        let depth = conclusion.depth;
+        return ProofTreeLayout {
+            width,
+            height,
+            depth,
+            children: vec![PlacedBox {
+                box_: conclusion,
+                x: 0.0,
+                baseline_y: height,
+            }],
+            rules: Vec::new(),
+        };
+    }
+
+    let premise_layouts: Vec<ProofTreeLayout> = tree
+        .premises
+        .iter()
+        .map(|p| layout_proof_branch(p, options))
+        .collect();
+
+    let premise_width = premise_layouts.iter().map(|p| p.width).sum::<f64>()
+        + premise_gap * premise_layouts.len().saturating_sub(1) as f64;
+    let premise_height = premise_layouts
+        .iter()
+        .map(|p| p.height)
+        .fold(0.0_f64, f64::max);
+    let premise_depth = premise_layouts
+        .iter()
+        .map(|p| p.depth)
+        .fold(0.0_f64, f64::max);
+    let premise_total = premise_height + premise_depth;
+
+    let rule_width = premise_width.max(conclusion.width).max(0.5);
+    let core_width = premise_width.max(rule_width).max(conclusion.width);
+    let center_x = core_width / 2.0;
+    let premise_start_x = center_x - premise_width / 2.0;
+    let rule_x = center_x - rule_width / 2.0;
+    let rule_y = premise_total + vertical_gap + rule_thickness / 2.0;
+    let conclusion_x = center_x - conclusion.width / 2.0;
+    let conclusion_baseline_y = rule_y + rule_thickness / 2.0 + vertical_gap + conclusion.height;
+
+    let mut children = Vec::new();
+    let mut rules = Vec::new();
+    let mut min_x = 0.0_f64;
+    let mut max_x = core_width;
+
+    let mut cursor = premise_start_x;
+    for premise in premise_layouts {
+        let baseline_y = premise_height;
+        let child_top_y = baseline_y - premise.height;
+        for child in premise.children {
+            let x = cursor + child.x;
+            let y = child_top_y + child.baseline_y;
+            min_x = min_x.min(x);
+            max_x = max_x.max(x + child.box_.width);
+            children.push(PlacedBox {
+                box_: child.box_,
+                x,
+                baseline_y: y,
+            });
+        }
+        for rule in premise.rules {
+            min_x = min_x.min(cursor + rule.x);
+            max_x = max_x.max(cursor + rule.x + rule.width);
+            rules.push(ProofRule {
+                x: cursor + rule.x,
+                y: child_top_y + rule.y,
+                width: rule.width,
+                thickness: rule.thickness,
+                dashed: rule.dashed,
+            });
+        }
+        cursor += premise.width + premise_gap;
+    }
+
+    min_x = min_x.min(conclusion_x);
+    max_x = max_x.max(conclusion_x + conclusion.width);
+    children.push(PlacedBox {
+        box_: conclusion,
+        x: conclusion_x,
+        baseline_y: conclusion_baseline_y,
+    });
+
+    if !matches!(tree.line_style, ProofLineStyle::None) {
+        rules.push(ProofRule {
+            x: rule_x,
+            y: rule_y,
+            width: rule_width,
+            thickness: rule_thickness,
+            dashed: matches!(tree.line_style, ProofLineStyle::Dashed),
+        });
+    }
+
+    if let Some(label) = tree.left_label.as_ref() {
+        let label_box = layout_expression(label, options, true);
+        let x = rule_x - label_gap - label_box.width;
+        let baseline_y = rule_y + (label_box.height - label_box.depth) / 2.0;
+        min_x = min_x.min(x);
+        max_x = max_x.max(x + label_box.width);
+        children.push(PlacedBox {
+            box_: label_box,
+            x,
+            baseline_y,
+        });
+    }
+
+    if let Some(label) = tree.right_label.as_ref() {
+        let label_box = layout_expression(label, options, true);
+        let x = rule_x + rule_width + label_gap;
+        let baseline_y = rule_y + (label_box.height - label_box.depth) / 2.0;
+        min_x = min_x.min(x);
+        max_x = max_x.max(x + label_box.width);
+        children.push(PlacedBox {
+            box_: label_box,
+            x,
+            baseline_y,
+        });
+    }
+
+    if min_x < 0.0 {
+        let shift = -min_x;
+        for child in &mut children {
+            child.x += shift;
+        }
+        for rule in &mut rules {
+            rule.x += shift;
+        }
+    }
+
+    ProofTreeLayout {
+        width: max_x - min_x,
+        height: conclusion_baseline_y,
+        depth: children
+            .iter()
+            .map(|c| c.baseline_y + c.box_.depth - conclusion_baseline_y)
+            .fold(0.0_f64, f64::max),
+        children,
+        rules,
     }
 }
 

--- a/crates/ratex-layout/src/layout_box.rs
+++ b/crates/ratex-layout/src/layout_box.rs
@@ -202,8 +202,30 @@ pub enum BoxContent {
         rule_thickness: f64,
     },
 
+    /// Bussproofs-style proof tree with absolutely placed child boxes and inference rules.
+    ProofTree {
+        children: Vec<PlacedBox>,
+        rules: Vec<ProofRule>,
+    },
+
     /// Empty placeholder.
     Empty,
+}
+
+#[derive(Debug, Clone)]
+pub struct PlacedBox {
+    pub box_: LayoutBox,
+    pub x: f64,
+    pub baseline_y: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProofRule {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub thickness: f64,
+    pub dashed: bool,
 }
 
 /// A child element in a vertical box.

--- a/crates/ratex-layout/src/to_display.rs
+++ b/crates/ratex-layout/src/to_display.rs
@@ -650,6 +650,30 @@ fn emit_box(
             });
         }
 
+        BoxContent::ProofTree { children, rules } => {
+            let top_y = y - lbox.height * scale;
+            for child in children {
+                emit_box(
+                    &child.box_,
+                    x + child.x * scale,
+                    top_y + child.baseline_y * scale,
+                    scale,
+                    items,
+                    font_str_cache,
+                );
+            }
+            for rule in rules {
+                items.push(DisplayItem::Line {
+                    x: x + rule.x * scale,
+                    y: top_y + rule.y * scale,
+                    width: rule.width * scale,
+                    thickness: rule.thickness * scale,
+                    color: lbox.color,
+                    dashed: rule.dashed,
+                });
+            }
+        }
+
         BoxContent::Kern | BoxContent::Empty => {}
     }
 }
@@ -794,4 +818,3 @@ fn shift_item_x(item: &mut DisplayItem, dx: f64) {
         DisplayItem::Path { x, .. } => *x += dx,
     }
 }
-

--- a/crates/ratex-layout/tests/layout_vs_katex.rs
+++ b/crates/ratex-layout/tests/layout_vs_katex.rs
@@ -69,6 +69,39 @@ fn htmlstyle_applies_supported_css() {
 }
 
 #[test]
+fn prooftree_binary_emits_inference_rule() {
+    let ast = parse("\\begin{prooftree}\\AxiomC{P}\\AxiomC{Q}\\BinaryInfC{R}\\end{prooftree}").unwrap();
+    let options = LayoutOptions::default();
+    let lbox = layout(&ast, &options);
+    let display = to_display_list(&lbox);
+
+    assert!(display.width > 0.0);
+    assert!(display.height > 0.0);
+    assert!(display.items.iter().any(|item| matches!(
+        item,
+        DisplayItem::Line { dashed: false, .. }
+    )));
+}
+
+#[test]
+fn prooftree_dashed_and_noline_rules() {
+    let dashed_ast = parse("\\begin{prooftree}\\AxiomC{P}\\dashedLine\\UnaryInfC{Q}\\end{prooftree}").unwrap();
+    let options = LayoutOptions::default();
+    let dashed_display = to_display_list(&layout(&dashed_ast, &options));
+    assert!(dashed_display.items.iter().any(|item| matches!(
+        item,
+        DisplayItem::Line { dashed: true, .. }
+    )));
+
+    let noline_ast = parse("\\begin{prooftree}\\AxiomC{P}\\noLine\\UnaryInfC{Q}\\end{prooftree}").unwrap();
+    let noline_display = to_display_list(&layout(&noline_ast, &options));
+    assert!(!noline_display.items.iter().any(|item| matches!(
+        item,
+        DisplayItem::Line { .. }
+    )));
+}
+
+#[test]
 fn single_char_uppercase() {
     check("A", 0.68333, 0.0);
 }

--- a/crates/ratex-parser/src/environments.rs
+++ b/crates/ratex-parser/src/environments.rs
@@ -4,7 +4,10 @@ use ratex_lexer::token::Token;
 
 use crate::error::{ParseError, ParseResult};
 use crate::macro_expander::MacroDefinition;
-use crate::parse_node::{AlignSpec, AlignType, ArrayTag, Measurement, Mode, ParseNode, StyleStr};
+use crate::parse_node::{
+    AlignSpec, AlignType, ArrayTag, Measurement, Mode, ParseNode, ProofBranch, ProofLineStyle,
+    StyleStr,
+};
 use crate::parser::Parser;
 
 // ── Environment registry ─────────────────────────────────────────────────
@@ -40,6 +43,7 @@ pub static ENVIRONMENTS: std::sync::LazyLock<HashMap<&'static str, EnvSpec>> =
         register_alignat(&mut map);
         register_subarray(&mut map);
         register_cd(&mut map);
+        register_prooftree(&mut map);
         map
     });
 
@@ -1236,4 +1240,144 @@ fn register_subarray(map: &mut HashMap<&'static str, EnvSpec>) {
             handler: handle_subarray,
         },
     );
+}
+
+// ── prooftree (bussproofs subset) ───────────────────────────────────────
+
+fn register_prooftree(map: &mut HashMap<&'static str, EnvSpec>) {
+    fn handle_prooftree(
+        ctx: &mut EnvContext,
+        _args: Vec<ParseNode>,
+        _opt_args: Vec<Option<ParseNode>>,
+    ) -> ParseResult<ParseNode> {
+        parse_prooftree(ctx.parser)
+    }
+
+    map.insert(
+        "prooftree",
+        EnvSpec {
+            num_args: 0,
+            num_optional_args: 0,
+            handler: handle_prooftree,
+        },
+    );
+}
+
+fn proof_command_arity(name: &str) -> Option<usize> {
+    match name {
+        "\\UnaryInfC" | "\\UnaryInf" | "\\UIC" => Some(1),
+        "\\BinaryInfC" | "\\BinaryInf" | "\\BIC" => Some(2),
+        "\\TrinaryInfC" | "\\TrinaryInf" | "\\TIC" => Some(3),
+        "\\QuaternaryInfC" | "\\QuaternaryInf" => Some(4),
+        "\\QuinaryInfC" | "\\QuinaryInf" => Some(5),
+        _ => None,
+    }
+}
+
+fn parse_prooftree_arg(parser: &mut Parser, command: &str) -> ParseResult<Vec<ParseNode>> {
+    let arg = parser.parse_argument_group(false, None)?.ok_or_else(|| {
+        ParseError::msg(format!("Expected argument for {}", command))
+    })?;
+    Ok(ParseNode::ord_argument(arg))
+}
+
+fn parse_prooftree(parser: &mut Parser) -> ParseResult<ParseNode> {
+    let mut stack: Vec<ProofBranch> = Vec::new();
+    let mut left_label: Option<Vec<ParseNode>> = None;
+    let mut right_label: Option<Vec<ParseNode>> = None;
+    let mut next_line_style = ProofLineStyle::Solid;
+    let mut default_line_style = ProofLineStyle::Solid;
+
+    loop {
+        parser.consume_spaces()?;
+        let token = parser.fetch()?;
+        let command = token.text.clone();
+
+        if command == "\\end" {
+            break;
+        }
+        parser.consume();
+
+        match command.as_str() {
+            "\\AxiomC" | "\\Axiom" | "\\AXC" => {
+                let conclusion = parse_prooftree_arg(parser, &command)?;
+                stack.push(ProofBranch {
+                    conclusion,
+                    premises: Vec::new(),
+                    left_label: None,
+                    right_label: None,
+                    line_style: ProofLineStyle::None,
+                });
+            }
+            "\\LeftLabel" | "\\LL" => {
+                left_label = Some(parse_prooftree_arg(parser, &command)?);
+            }
+            "\\RightLabel" | "\\RL" => {
+                right_label = Some(parse_prooftree_arg(parser, &command)?);
+            }
+            "\\singleLine" | "\\solidLine" => {
+                next_line_style = ProofLineStyle::Solid;
+            }
+            "\\dashedLine" => {
+                next_line_style = ProofLineStyle::Dashed;
+            }
+            "\\noLine" => {
+                next_line_style = ProofLineStyle::None;
+            }
+            "\\alwaysSingleLine" | "\\alwaysSolidLine" => {
+                default_line_style = ProofLineStyle::Solid;
+                next_line_style = ProofLineStyle::Solid;
+            }
+            "\\alwaysDashedLine" => {
+                default_line_style = ProofLineStyle::Dashed;
+                next_line_style = ProofLineStyle::Dashed;
+            }
+            "\\alwaysNoLine" => {
+                default_line_style = ProofLineStyle::None;
+                next_line_style = ProofLineStyle::None;
+            }
+            "\\rootAtTop" | "\\rootAtBottom" | "\\alwaysRootAtTop" | "\\alwaysRootAtBottom" => {}
+            name if proof_command_arity(name).is_some() => {
+                let arity = proof_command_arity(name).unwrap();
+                if stack.len() < arity {
+                    return Err(ParseError::msg(format!(
+                        "{} needs {} premise(s), but only {} available",
+                        name,
+                        arity,
+                        stack.len()
+                    )));
+                }
+                let conclusion = parse_prooftree_arg(parser, name)?;
+                let start = stack.len() - arity;
+                let premises = stack.split_off(start);
+                stack.push(ProofBranch {
+                    conclusion,
+                    premises,
+                    left_label: left_label.take(),
+                    right_label: right_label.take(),
+                    line_style: next_line_style.clone(),
+                });
+                next_line_style = default_line_style.clone();
+            }
+            _ => {
+                return Err(ParseError::msg(format!(
+                    "{} valid only as a supported bussproofs command within prooftree",
+                    command
+                )));
+            }
+        }
+    }
+
+    if stack.len() != 1 {
+        return Err(ParseError::msg(format!(
+            "prooftree ended with {} proof stack item(s), expected 1",
+            stack.len()
+        )));
+    }
+
+    Ok(ParseNode::ProofTree {
+        mode: parser.mode,
+        tree: stack.pop().unwrap(),
+        loc: None,
+    })
 }

--- a/crates/ratex-parser/src/functions/bussproofs.rs
+++ b/crates/ratex-parser/src/functions/bussproofs.rs
@@ -1,0 +1,33 @@
+use std::collections::HashMap;
+
+use crate::error::ParseResult;
+use crate::functions::{define_function_full, FunctionContext, FunctionSpec};
+use crate::parse_node::ParseNode;
+
+pub fn register(map: &mut HashMap<&'static str, FunctionSpec>) {
+    define_function_full(
+        map,
+        &["\\fCenter"],
+        "internal",
+        0,
+        0,
+        None,
+        true,
+        true,
+        true,
+        false,
+        false,
+        handle_fcenter,
+    );
+}
+
+fn handle_fcenter(
+    ctx: &mut FunctionContext,
+    _args: Vec<ParseNode>,
+    _opt_args: Vec<Option<ParseNode>>,
+) -> ParseResult<ParseNode> {
+    Ok(ParseNode::Internal {
+        mode: ctx.parser.mode,
+        loc: None,
+    })
+}

--- a/crates/ratex-parser/src/functions/mod.rs
+++ b/crates/ratex-parser/src/functions/mod.rs
@@ -37,6 +37,7 @@ pub mod char_cmd;
 pub mod math;
 pub mod tag;
 pub mod nonumber;
+pub mod bussproofs;
 
 use std::collections::HashMap;
 use crate::error::ParseResult;
@@ -127,6 +128,7 @@ pub static FUNCTIONS: std::sync::LazyLock<HashMap<&'static str, FunctionSpec>> =
         math::register(&mut map);
         tag::register(&mut map);
         nonumber::register(&mut map);
+        bussproofs::register(&mut map);
         map
     });
 

--- a/crates/ratex-parser/src/parse_node.rs
+++ b/crates/ratex-parser/src/parse_node.rs
@@ -58,6 +58,28 @@ pub enum AlignType {
     Separator,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ProofLineStyle {
+    Solid,
+    Dashed,
+    None,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProofBranch {
+    pub conclusion: Vec<ParseNode>,
+    pub premises: Vec<ProofBranch>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "leftLabel")]
+    pub left_label: Option<Vec<ParseNode>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "rightLabel")]
+    pub right_label: Option<Vec<ParseNode>>,
+    #[serde(rename = "lineStyle")]
+    pub line_style: ProofLineStyle,
+}
+
 /// The main AST node type. Each variant corresponds to a KaTeX ParseNode type.
 ///
 /// Serializes to JSON with `"type": "variant_name"` to match KaTeX's format,
@@ -692,6 +714,14 @@ pub enum ParseNode {
         #[serde(skip_serializing_if = "Option::is_none")]
         loc: Option<SourceLocation>,
     },
+
+    #[serde(rename = "proofTree")]
+    ProofTree {
+        mode: Mode,
+        tree: ProofBranch,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        loc: Option<SourceLocation>,
+    },
 }
 
 fn default_arraystretch() -> f64 {
@@ -769,7 +799,8 @@ impl ParseNode {
             | Self::IncludeGraphics { mode, .. }
             | Self::CdLabel { mode, .. }
             | Self::CdLabelParent { mode, .. }
-            | Self::CdArrow { mode, .. } => *mode,
+            | Self::CdArrow { mode, .. }
+            | Self::ProofTree { mode, .. } => *mode,
         }
     }
 
@@ -834,6 +865,7 @@ impl ParseNode {
             Self::CdLabel { .. } => "cdlabel",
             Self::CdLabelParent { .. } => "cdlabelparent",
             Self::CdArrow { .. } => "cdArrow",
+            Self::ProofTree { .. } => "proofTree",
         }
     }
 

--- a/crates/ratex-parser/src/tests.rs
+++ b/crates/ratex-parser/src/tests.rs
@@ -948,6 +948,38 @@ mod environments {
     }
 
     #[test]
+    fn prooftree_unary_with_label_and_abbreviations() {
+        let ast = parse("\\begin{prooftree}\\AXC{P}\\RL{r}\\UIC{Q}\\end{prooftree}").unwrap();
+        assert_eq!(ast.len(), 1);
+        assert_eq!(ast[0].type_name(), "proofTree");
+        if let ParseNode::ProofTree { tree, .. } = &ast[0] {
+            assert_eq!(tree.premises.len(), 1);
+            assert!(tree.left_label.is_none());
+            assert!(tree.right_label.is_some());
+            assert_eq!(tree.conclusion.len(), 1);
+        } else {
+            panic!("Expected ProofTree node");
+        }
+    }
+
+    #[test]
+    fn prooftree_binary_dashed_line() {
+        let ast = parse("\\begin{prooftree}\\AxiomC{P}\\AxiomC{Q}\\dashedLine\\BinaryInfC{R}\\end{prooftree}").unwrap();
+        if let ParseNode::ProofTree { tree, .. } = &ast[0] {
+            assert_eq!(tree.premises.len(), 2);
+            assert!(matches!(tree.line_style, crate::parse_node::ProofLineStyle::Dashed));
+        } else {
+            panic!("Expected ProofTree node");
+        }
+    }
+
+    #[test]
+    fn prooftree_errors_on_short_stack() {
+        let result = parse("\\begin{prooftree}\\AxiomC{P}\\BinaryInfC{Q}\\end{prooftree}");
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn vmatrix_double_wraps() {
         let ast =
             parse("\\begin{Vmatrix} a & b \\\\ c & d \\end{Vmatrix}").unwrap();


### PR DESCRIPTION
## Feature: bussproofs prooftree support

### Description

Hi there! This PR adds a subset of `bussproofs` style proof tree layout and parsing support to RaTeX. It allows users to write natural deduction and sequent calculus proofs directly within a `prooftree` environment.

<img width="1691" height="494" alt="example_prooftree" src="https://github.com/user-attachments/assets/ad3e87b8-8e7e-4b08-9712-7c61114ba466" />


> Note: The implementation of this code was assisted by OpenAI's Codex.

### Key Changes

* **Parser Additions (`ratex-parser`):**
* Registered the `prooftree` environment, which is available on MathJax, not KaTeX.
* Implemented parsing logic for core commands like `\AxiomC` (`\AXC`), `\UnaryInfC` (`\UIC`), `\BinaryInfC` (`\BIC`), etc.
* Added support for proof line modifiers (`\dashedLine`, `\noLine`) and labels (`\LeftLabel` / `\LL`, `\RightLabel` / `\RL`).
* Introduced an internal `\fCenter` function mapping.


* **Layout Engine (`ratex-layout`):**
* Added a recursive layout algorithm (`layout_proof_branch`) that automatically calculates proper alignment, rule widths, and heights for complex proof branches.
* Added support for rendering dashed and solid lines dynamically based on style requirements.


* **Testing:** Added comprehensive unit and layout verification tests to check binary inferences, line styles, and short-stack validation errors.

### How to Test

You can check out the newly added tests in:

* `crates/ratex-layout/tests/layout_vs_katex.rs`
* `crates/ratex-parser/src/tests.rs`

Let me know if you have any feedback or if there's anything else you'd like me to tweak! Thanks for reviewing!