### PR TITLE
feat(svg): support stdout output for SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ printf '%s\n' '\frac{1}{2} + \sqrt{x}' | ./target/release/render --output-dir ./
 printf '%s\n' '\int_0^\infty e^{-x^2} dx = \frac{\sqrt{\pi}}{2}' | \
   ./target/release/render-svg --font-dir /path/to/katex/fonts --color '#1E88E5' --output-dir ./out
 
+# SVG: write the rendered SVG document to stdout instead of a file
+printf '%s\n' '\frac{1}{2} + \sqrt{x}' | ./target/release/render-svg --stdout > formula.svg
+
 # PDF: load KaTeX TTFs at runtime
 printf '%s\n' '\ce{H2SO4 + 2NaOH -> Na2SO4 + 2H2O}' | \
   ./target/release/render-pdf --font-dir /path/to/katex/fonts --output-dir ./out
@@ -233,6 +236,7 @@ CLI notes
 
 - `--input <FILE>`: read formulas from a file, one per line.
 - `--output-dir <DIR>`: output directory. Defaults are `output`, `output_svg`, and `output_pdf`.
+- `render-svg --stdout`: write SVG documents to stdout instead of files; status messages go to stderr.
 - `--help`: show supported options and whether the current build uses embedded fonts.
 - `--color` / `--background-color` accept named colors (for example `black`, `red`, `teal`), 3- or 6-digit hex (`#f00`, `#ff0000`), and KaTeX / MathJax-style color model values (`[RGB]255,0,0`, `[rgb]1,0,0`, `[HTML]B22222`, `[gray]0.5`, `[cmyk]0,1,1,0`).
 - `ratex-render --background-color transparent` produces a transparent PNG.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -217,6 +217,9 @@ printf '%s\n' '\frac{1}{2} + \sqrt{x}' | ./target/release/render --output-dir ./
 printf '%s\n' '\int_0^\infty e^{-x^2} dx = \frac{\sqrt{\pi}}{2}' | \
   ./target/release/render-svg --font-dir /path/to/katex/fonts --color '#1E88E5' --output-dir ./out
 
+# SVG：将渲染后的 SVG 文档写到 stdout，而不是文件
+printf '%s\n' '\frac{1}{2} + \sqrt{x}' | ./target/release/render-svg --stdout > formula.svg
+
 # PDF：运行时从 KaTeX TTF 目录加载字体
 printf '%s\n' '\ce{H2SO4 + 2NaOH -> Na2SO4 + 2H2O}' | \
   ./target/release/render-pdf --font-dir /path/to/katex/fonts --output-dir ./out
@@ -232,6 +235,7 @@ CLI 说明
 
 - `--input <FILE>`：从文件读取公式，每行一条公式。
 - `--output-dir <DIR>`：输出目录。默认分别是 `output`、`output_svg`、`output_pdf`。
+- `render-svg --stdout`：将 SVG 文档写到 stdout，而不是文件；状态信息写到 stderr。
 - `--help`：查看当前二进制支持的选项，以及当前构建是否启用了嵌入字体。
 - `--color` / `--background-color` 支持命名颜色（如 `black`、`red`、`teal`）、三位或六位十六进制（如 `#f00`、`#ff0000`）、以及 KaTeX / MathJax 风格的颜色模型写法（如 `[RGB]255,0,0`、`[rgb]1,0,0`、`[HTML]B22222`、`[gray]0.5`、`[cmyk]0,1,1,0`）。
 - `ratex-render` 的 `--background-color transparent` 可输出透明背景 PNG。

--- a/crates/ratex-svg/src/bin/render_svg.rs
+++ b/crates/ratex-svg/src/bin/render_svg.rs
@@ -1,7 +1,7 @@
 //! Batch-export golden cases to standalone SVG (path glyphs, same scale as `ratex-render` + DPR).
 
 use std::fs::File;
-use std::io::{self, BufRead};
+use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
 
 use ratex_layout::{layout, to_display_list, LayoutOptions};
@@ -33,6 +33,8 @@ fn main() {
         .and_then(|i| args.get(i + 1))
         .cloned()
         .unwrap_or_else(|| "output_svg".to_string());
+
+    let stdout = args.iter().any(|a| a == "--stdout");
 
     let device_pixel_ratio = args
         .iter()
@@ -66,7 +68,9 @@ fn main() {
         .and_then(|i| args.get(i + 1))
         .cloned();
 
-    std::fs::create_dir_all(&output_dir).expect("Failed to create output dir");
+    if !stdout {
+        std::fs::create_dir_all(&output_dir).expect("Failed to create output dir");
+    }
 
     let dpr = device_pixel_ratio.clamp(0.01, 16.0) as f64;
     let svg_opts = SvgOptions {
@@ -98,9 +102,20 @@ fn main() {
         idx += 1;
         match svg_formula(expr, &layout_opts, &svg_opts) {
             Ok(svg) => {
-                let path = PathBuf::from(&output_dir).join(format!("{:04}.svg", idx));
-                std::fs::write(&path, svg.as_bytes()).expect("Failed to write SVG");
-                println!("OK  {:4} {}", idx, expr);
+                if stdout {
+                    let mut handle = io::stdout().lock();
+                    handle
+                        .write_all(svg.as_bytes())
+                        .expect("Failed to write SVG to stdout");
+                    handle
+                        .write_all(b"\n")
+                        .expect("Failed to write SVG to stdout");
+                    eprintln!("OK  {:4} {}", idx, expr);
+                } else {
+                    let path = PathBuf::from(&output_dir).join(format!("{:04}.svg", idx));
+                    std::fs::write(&path, svg.as_bytes()).expect("Failed to write SVG");
+                    println!("OK  {:4} {}", idx, expr);
+                }
             }
             Err(e) => {
                 eprintln!("ERR {:4} {} — {}", idx, expr, e);
@@ -108,7 +123,11 @@ fn main() {
         }
     }
 
-    println!("\nWrote {} SVG(s) to {}/", idx, output_dir);
+    if stdout {
+        eprintln!("\nWrote {} SVG(s) to stdout", idx);
+    } else {
+        println!("\nWrote {} SVG(s) to {}/", idx, output_dir);
+    }
 }
 
 fn svg_formula(
@@ -172,6 +191,7 @@ Options:
   -h, --help                 Show this help message
   --input <FILE>             Read formulas from file instead of stdin
 {font_dir_option}  --output-dir <DIR>         Write SVGs to this directory [default: output_svg]
+  --stdout                   Write SVGs to stdout instead of files
   --dpr <FACTOR>             Scale font size, padding, and stroke width [default: 1.0]
   --font-size <SIZE>         Base SVG font size in user units [default: 40.0]
   --color <COLOR>            Formula color: named, #rgb, #rrggbb, or [MODEL]value


### PR DESCRIPTION
Adds a `--stdout` option to the `render-svg` CLI so rendered SVG documents can be written directly to stdout instead of files. This enables server-side integrations to pipe formulas into `render-svg` and capture the rendered SVG from process output.

Closes #95.

## Changes
- Add `render-svg --stdout`.
- Skip `--output-dir` creation when writing to stdout.
- Write SVG content to stdout.
- Write progress and error messages to stderr in stdout mode so stdout remains capture-safe.
- Document the new option in the English and Chinese READMEs.
## Testing
- `cargo test -p ratex-svg --features "cli embed-fonts"`
- `printf '%s\n' '\frac{1}{2} + \sqrt{x}' | cargo run -q -p ratex-svg --features "cli embed-fonts" -- --stdout > /tmp/opencode/ratex-stdout.svg 2> /tmp/opencode/ratex-stdout.err`