### PR TITLE
feat: add GTK4 native rendering and GI bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,10 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - name: Install CJK font (for ratex-unicode-font tests)
-        run: sudo apt-get update && sudo apt-get install -y fonts-noto-cjk
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y fonts-noto-cjk libgtk-4-dev libadwaita-1-dev libcairo2-dev
       - name: Build
         run: cargo build --workspace
       - name: Clippy
@@ -63,6 +65,72 @@ jobs:
           cd platforms/web
           npm ci
           npm run build
+
+  gtk-gobject-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install GTK/GI tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential gobject-introspection libgirepository1.0-dev libgtk-4-dev libadwaita-1-dev libcairo2-dev python3-gi python3-gi-cairo valac xvfb
+      - name: Build RatexGtk library and Rust demos
+        run: cargo build -p ratex-gtk4 --lib --example formula_demo --example adw_formula_demo
+      - name: Compile RatexGtk typelib
+        run: g-ir-compiler platforms/gtk/gir/RatexGtk-1.0.gir -o target/debug/RatexGtk-1.0.typelib
+      - name: Build C example
+        run: |
+          gcc platforms/gtk/examples/c/formula_demo.c \
+            -o target/debug/ratex-gtk-c-demo \
+            -Iplatforms/gtk/include/ratex-gtk-1.0 \
+            -Ltarget/debug -lratex_gtk4 \
+            $(pkg-config --cflags --libs gtk4) \
+            -Wl,-rpath,$PWD/target/debug
+          gcc platforms/gtk/examples/c/init_contract.c \
+            -o target/debug/ratex-gtk-c-init-contract \
+            -Iplatforms/gtk/include/ratex-gtk-1.0 \
+            -Ltarget/debug -lratex_gtk4 \
+            $(pkg-config --cflags --libs gtk4) \
+            -Wl,-rpath,$PWD/target/debug
+      - name: Validate GTK metadata consistency
+        run: |
+          nm -D --defined-only target/debug/libratex_gtk4.so | grep -q ' ratex_formula_get_type$'
+          nm -D --defined-only target/debug/libratex_gtk4.so | grep -q ' ratex_formula_new$'
+          grep -q 'RatexFormula \*ratex_formula_new(void);' platforms/gtk/include/ratex-gtk-1.0/ratex-gtk.h
+          for property in latex display-mode font-size padding color font-dir error-message; do
+            grep -q "property name=\"$property\"" platforms/gtk/gir/RatexGtk-1.0.gir
+            grep -q "${property//-/_}" platforms/gtk/vapi/ratex-gtk-1.0.vapi
+          done
+      - name: Build Vala example
+        run: |
+          valac --vapidir=platforms/gtk/vapi \
+            --pkg gtk4 --pkg ratex-gtk-1.0 \
+            -X -Iplatforms/gtk/include/ratex-gtk-1.0 \
+            -X -Ltarget/debug -X -lratex_gtk4 \
+            -X -Wl,-rpath,$PWD/target/debug \
+            platforms/gtk/examples/vala/formula_demo.vala \
+            -o target/debug/ratex-gtk-vala-demo
+      - name: Smoke examples under Xvfb
+        run: |
+          export LD_LIBRARY_PATH=$PWD/target/debug:${LD_LIBRARY_PATH:-}
+          export GI_TYPELIB_PATH=$PWD/target/debug:${GI_TYPELIB_PATH:-}
+          run_smoke() {
+            set +e
+            timeout 5s xvfb-run -a "$@"
+            status=$?
+            set -e
+            if [ "$status" -ne 0 ] && [ "$status" -ne 124 ]; then
+              return "$status"
+            fi
+          }
+          run_smoke cargo run -p ratex-gtk4 --example formula_demo
+          run_smoke cargo run -p ratex-gtk4 --example adw_formula_demo
+          xvfb-run -a target/debug/ratex-gtk-c-init-contract
+          run_smoke target/debug/ratex-gtk-c-demo
+          run_smoke python3 platforms/gtk/examples/python/formula_demo.py
+          run_smoke target/debug/ratex-gtk-vala-demo
 
   ios-swift-smoke:
     runs-on: macos-15

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ members = [
     "crates/ratex-katex-fonts",
     "crates/ratex-font-loader",
     "crates/ratex-ffi",
+    "crates/ratex-cairo",
+    "crates/ratex-gtk4",
     "crates/ratex-render",
     "crates/ratex-svg",
     "crates/ratex-wasm",
@@ -33,6 +35,7 @@ ratex-parser = { path = "crates/ratex-parser", version = "0.1.11" }
 ratex-layout = { path = "crates/ratex-layout", version = "0.1.11" }
 ratex-katex-fonts = { path = "crates/ratex-katex-fonts", version = "0.1.11" }
 ratex-font-loader = { path = "crates/ratex-font-loader", version = "0.1.11" }
+ratex-cairo  = { path = "crates/ratex-cairo", version = "0.1.11" }
 ratex-svg    = { path = "crates/ratex-svg", version = "0.1.11" }
 ratex-pdf    = { path = "crates/ratex-pdf", version = "0.1.11" }
 ratex-unicode-font = { path = "crates/ratex-unicode-font", version = "0.1.11" }

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ See [`platforms/web/README.md`](platforms/web/README.md) for the full setup.
 |---|---|
 | iOS | [`platforms/ios/README.md`](platforms/ios/README.md) |
 | Android | [`platforms/android/README.md`](platforms/android/README.md) |
+| GTK4 (Linux) | [`platforms/gtk/README.md`](platforms/gtk/README.md) |
 | Flutter | [`platforms/flutter/README.md`](platforms/flutter/README.md) |
 | React Native | [`platforms/react-native/README.md`](platforms/react-native/README.md) |
 | Compose Multiplatform | [`RaTeX-CMP`](https://github.com/darriousliu/RaTeX-CMP) |

--- a/crates/ratex-cairo/Cargo.toml
+++ b/crates/ratex-cairo/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ratex-cairo"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "Cairo renderer for RaTeX DisplayList"
+
+[features]
+default = ["embed-fonts"]
+embed-fonts = ["dep:ratex-katex-fonts", "ratex-font-loader/embed-fonts"]
+
+[dependencies]
+ratex-types = { workspace = true }
+ratex-font = { workspace = true }
+ratex-font-loader = { workspace = true }
+ratex-katex-fonts = { workspace = true, optional = true }
+ratex-unicode-font = { workspace = true }
+ab_glyph = "0.2"
+cairo-rs = { version = "0.20", features = ["png"] }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+ratex-layout = { workspace = true }
+ratex-parser = { workspace = true }

--- a/crates/ratex-cairo/src/lib.rs
+++ b/crates/ratex-cairo/src/lib.rs
@@ -1,0 +1,782 @@
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+
+use ab_glyph::{Font, FontRef, OutlineCurve};
+use ratex_font::FontId;
+use ratex_font_loader::FontSet;
+use ratex_types::{Color, DisplayItem, DisplayList, PathCommand};
+use thiserror::Error;
+
+#[derive(Debug, Clone)]
+pub struct CairoOptions {
+    pub font_size: f64,
+    pub padding: f64,
+    pub font_dir: Option<PathBuf>,
+}
+
+impl Default for CairoOptions {
+    fn default() -> Self {
+        Self {
+            font_size: 24.0,
+            padding: 4.0,
+            font_dir: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RenderMetrics {
+    pub width: f64,
+    pub total_height: f64,
+    pub baseline: f64,
+}
+
+#[derive(Debug, Error)]
+pub enum CairoError {
+    #[error("font error: {0}")]
+    Font(String),
+    #[error("cairo error: {0}")]
+    Cairo(String),
+}
+
+pub fn measure_display_list(display_list: &DisplayList, options: &CairoOptions) -> RenderMetrics {
+    let width = display_list.width * options.font_size + 2.0 * options.padding;
+    let baseline = display_list.height * options.font_size + options.padding;
+    let total_height = display_list.total_height() * options.font_size + 2.0 * options.padding;
+    RenderMetrics {
+        width: width.max(1.0),
+        total_height: total_height.max(1.0),
+        baseline: baseline.max(0.0),
+    }
+}
+
+pub fn render_to_cairo(
+    cr: &cairo::Context,
+    display_list: &DisplayList,
+    options: &CairoOptions,
+) -> Result<(), CairoError> {
+    cr.set_antialias(cairo::Antialias::Best);
+
+    let font_dir = options
+        .font_dir
+        .as_deref()
+        .and_then(Path::to_str)
+        .unwrap_or("");
+    let fonts = ratex_font_loader::load_fonts_for_items(font_dir, &display_list.items)
+        .map_err(CairoError::Font)?;
+    let font_refs = build_font_refs(&fonts).map_err(CairoError::Font)?;
+
+    let em = options.font_size as f32;
+    let pad = options.padding as f32;
+    let mut font_id_cache: HashMap<&str, FontId> = HashMap::new();
+
+    for item in &display_list.items {
+        match item {
+            DisplayItem::GlyphPath {
+                x,
+                y,
+                scale,
+                font,
+                char_code,
+                color,
+            } => {
+                let font_id = *font_id_cache
+                    .entry(font.as_str())
+                    .or_insert_with(|| FontId::parse(font).unwrap_or(FontId::MainRegular));
+                render_glyph(
+                    cr,
+                    *x as f32 * em + pad,
+                    *y as f32 * em + pad,
+                    font_id,
+                    *char_code,
+                    *color,
+                    &font_refs,
+                    *scale as f32 * em,
+                )?;
+            }
+            DisplayItem::Line {
+                x,
+                y,
+                width,
+                thickness,
+                color,
+                dashed,
+            } => render_line(
+                cr,
+                *x as f32 * em + pad,
+                *y as f32 * em + pad,
+                *width as f32 * em,
+                *thickness as f32 * em,
+                *color,
+                *dashed,
+            )?,
+            DisplayItem::Rect {
+                x,
+                y,
+                width,
+                height,
+                color,
+            } => render_rect(
+                cr,
+                *x as f32 * em + pad,
+                *y as f32 * em + pad,
+                *width as f32 * em,
+                *height as f32 * em,
+                *color,
+            )?,
+            DisplayItem::Path {
+                x,
+                y,
+                commands,
+                fill,
+                color,
+            } => render_path(
+                cr,
+                *x as f32 * em + pad,
+                *y as f32 * em + pad,
+                commands,
+                *fill,
+                *color,
+                em,
+            )?,
+        }
+    }
+
+    Ok(())
+}
+
+fn build_font_refs(data: &FontSet) -> Result<HashMap<FontId, FontRef<'_>>, String> {
+    let mut font_refs = HashMap::new();
+    for (id, bytes) in data.iter() {
+        let font = FontRef::try_from_slice_and_index(bytes, sfnt_collection_index(*id))
+            .map_err(|e| format!("Failed to parse font {:?}: {}", id, e))?;
+        font_refs.insert(*id, font);
+    }
+
+    if !font_refs.contains_key(&FontId::MainRegular) {
+        return Err("Main-Regular font not found".to_string());
+    }
+
+    Ok(font_refs)
+}
+
+fn sfnt_collection_index(id: FontId) -> u32 {
+    match id {
+        FontId::EmojiFallback => ratex_unicode_font::emoji_font_face_index().unwrap_or(0),
+        FontId::CjkRegular => ratex_unicode_font::unicode_font_face_index().unwrap_or(0),
+        FontId::CjkFallback => ratex_unicode_font::fallback_font_face_index().unwrap_or(0),
+        _ => 0,
+    }
+}
+
+fn render_glyph(
+    cr: &cairo::Context,
+    px: f32,
+    py: f32,
+    font_id: FontId,
+    char_code: u32,
+    color: Color,
+    font_cache: &HashMap<FontId, FontRef<'_>>,
+    em: f32,
+) -> Result<(), CairoError> {
+    let font = match font_cache.get(&font_id) {
+        Some(font) => font,
+        None => font_cache
+            .get(&FontId::MainRegular)
+            .ok_or_else(|| CairoError::Font("Main-Regular font not found".to_string()))?,
+    };
+
+    let ch = ratex_font::katex_ttf_glyph_char(font_id, char_code);
+    let glyph_id = font.glyph_id(ch);
+
+    if glyph_id.0 == 0 {
+        let _ = try_system_unicode_fallback(cr, px, py, ch, color, em, font_cache, false)?;
+        return Ok(());
+    }
+
+    if font_id == FontId::EmojiFallback {
+        if try_draw_emoji_png(cr, px, py, em, ch)? {
+            return Ok(());
+        }
+        if render_glyph_with_font(
+            cr,
+            px,
+            py,
+            FontGlyph {
+                font_id,
+                font,
+                glyph_id,
+            },
+            color,
+            em,
+        )? {
+            return Ok(());
+        }
+    }
+
+    if font_id == FontId::CjkRegular {
+        if render_glyph_with_font(
+            cr,
+            px,
+            py,
+            FontGlyph {
+                font_id,
+                font,
+                glyph_id,
+            },
+            color,
+            em,
+        )? {
+            return Ok(());
+        }
+        if try_draw_emoji_or_outline(cr, px, py, ch, color, em, font_cache)? {
+            return Ok(());
+        }
+        if let Some(fallback_font) = font_cache.get(&FontId::CjkFallback) {
+            let fallback_id = fallback_font.glyph_id(ch);
+            if fallback_id.0 != 0 {
+                let _ = render_glyph_with_font(
+                    cr,
+                    px,
+                    py,
+                    FontGlyph {
+                        font_id: FontId::CjkFallback,
+                        font: fallback_font,
+                        glyph_id: fallback_id,
+                    },
+                    color,
+                    em,
+                )?;
+            }
+        }
+        return Ok(());
+    }
+
+    if font_id == FontId::CjkFallback {
+        if render_glyph_with_font(
+            cr,
+            px,
+            py,
+            FontGlyph {
+                font_id,
+                font,
+                glyph_id,
+            },
+            color,
+            em,
+        )? {
+            return Ok(());
+        }
+        let _ = try_draw_emoji_or_outline(cr, px, py, ch, color, em, font_cache)?;
+        return Ok(());
+    }
+
+    if render_glyph_with_font(
+        cr,
+        px,
+        py,
+        FontGlyph {
+            font_id,
+            font,
+            glyph_id,
+        },
+        color,
+        em,
+    )? {
+        return Ok(());
+    }
+
+    let skip_main = font_id == FontId::MainRegular;
+    let _ = try_system_unicode_fallback(cr, px, py, ch, color, em, font_cache, skip_main)?;
+    Ok(())
+}
+
+fn try_system_unicode_fallback(
+    cr: &cairo::Context,
+    px: f32,
+    py: f32,
+    ch: char,
+    color: Color,
+    em: f32,
+    font_cache: &HashMap<FontId, FontRef<'_>>,
+    skip_main_regular: bool,
+) -> Result<bool, CairoError> {
+    if !skip_main_regular {
+        if let Some(font) = font_cache.get(&FontId::MainRegular) {
+            let glyph_id = font.glyph_id(ch);
+            if glyph_id.0 != 0
+                && render_glyph_with_font(
+                    cr,
+                    px,
+                    py,
+                    FontGlyph {
+                        font_id: FontId::MainRegular,
+                        font,
+                        glyph_id,
+                    },
+                    color,
+                    em,
+                )?
+            {
+                return Ok(true);
+            }
+        }
+    }
+
+    if let Some(font) = font_cache.get(&FontId::CjkRegular) {
+        let glyph_id = font.glyph_id(ch);
+        if glyph_id.0 != 0
+            && render_glyph_with_font(
+                cr,
+                px,
+                py,
+                FontGlyph {
+                    font_id: FontId::CjkRegular,
+                    font,
+                    glyph_id,
+                },
+                color,
+                em,
+            )?
+        {
+            return Ok(true);
+        }
+    }
+
+    if try_draw_emoji_or_outline(cr, px, py, ch, color, em, font_cache)? {
+        return Ok(true);
+    }
+
+    if let Some(font) = font_cache.get(&FontId::CjkFallback) {
+        let glyph_id = font.glyph_id(ch);
+        if glyph_id.0 != 0
+            && render_glyph_with_font(
+                cr,
+                px,
+                py,
+                FontGlyph {
+                    font_id: FontId::CjkFallback,
+                    font,
+                    glyph_id,
+                },
+                color,
+                em,
+            )?
+        {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn try_draw_emoji_or_outline(
+    cr: &cairo::Context,
+    px: f32,
+    py: f32,
+    ch: char,
+    color: Color,
+    em: f32,
+    font_cache: &HashMap<FontId, FontRef<'_>>,
+) -> Result<bool, CairoError> {
+    if try_draw_emoji_png(cr, px, py, em, ch)? {
+        return Ok(true);
+    }
+
+    if let Some(font) = font_cache.get(&FontId::EmojiFallback) {
+        let glyph_id = font.glyph_id(ch);
+        if glyph_id.0 != 0 {
+            return render_glyph_with_font(
+                cr,
+                px,
+                py,
+                FontGlyph {
+                    font_id: FontId::EmojiFallback,
+                    font,
+                    glyph_id,
+                },
+                color,
+                em,
+            );
+        }
+    }
+
+    Ok(false)
+}
+
+struct FontGlyph<'a> {
+    font_id: FontId,
+    font: &'a FontRef<'a>,
+    glyph_id: ab_glyph::GlyphId,
+}
+
+fn render_glyph_with_font(
+    cr: &cairo::Context,
+    px: f32,
+    py: f32,
+    glyph: FontGlyph<'_>,
+    color: Color,
+    em: f32,
+) -> Result<bool, CairoError> {
+    let curves = match ratex_font_loader::outline_cache::get_or_compute_outline(
+        glyph.font_id,
+        glyph.font,
+        glyph.glyph_id,
+    ) {
+        Some(curves) => curves,
+        None => return Ok(false),
+    };
+    if curves.is_empty() {
+        return Ok(false);
+    }
+
+    let units_per_em = glyph.font.units_per_em().unwrap_or(1000.0);
+    let mut scale = em / units_per_em;
+    if glyph.font_id == FontId::EmojiFallback {
+        let actual_advance = glyph.font.h_advance_unscaled(glyph.glyph_id);
+        let actual_advance_em = actual_advance / units_per_em;
+        if actual_advance_em > 0.01 && actual_advance_em > 1.01 {
+            scale *= 1.0 / actual_advance_em;
+        }
+    }
+
+    append_outline_path(cr, &curves, px, py, scale);
+    set_source_color(cr, color);
+    cr.fill()
+        .map_err(|err| CairoError::Cairo(err.to_string()))?;
+    Ok(true)
+}
+
+fn append_outline_path(cr: &cairo::Context, curves: &[OutlineCurve], px: f32, py: f32, scale: f32) {
+    let mut last_end: Option<(f32, f32)> = None;
+
+    for curve in curves {
+        let (start, end) = match curve {
+            OutlineCurve::Line(p0, p1) => {
+                let sx = px + p0.x * scale;
+                let sy = py - p0.y * scale;
+                let ex = px + p1.x * scale;
+                let ey = py - p1.y * scale;
+                ((sx, sy), (ex, ey))
+            }
+            OutlineCurve::Quad(p0, _, p2) => {
+                let sx = px + p0.x * scale;
+                let sy = py - p0.y * scale;
+                let ex = px + p2.x * scale;
+                let ey = py - p2.y * scale;
+                ((sx, sy), (ex, ey))
+            }
+            OutlineCurve::Cubic(p0, _, _, p3) => {
+                let sx = px + p0.x * scale;
+                let sy = py - p0.y * scale;
+                let ex = px + p3.x * scale;
+                let ey = py - p3.y * scale;
+                ((sx, sy), (ex, ey))
+            }
+        };
+
+        let need_move = match last_end {
+            None => true,
+            Some((lx, ly)) => (lx - start.0).abs() > 0.01 || (ly - start.1).abs() > 0.01,
+        };
+
+        if need_move {
+            if last_end.is_some() {
+                cr.close_path();
+            }
+            cr.move_to(start.0 as f64, start.1 as f64);
+        }
+
+        match curve {
+            OutlineCurve::Line(_, p1) => {
+                cr.line_to((px + p1.x * scale) as f64, (py - p1.y * scale) as f64);
+            }
+            OutlineCurve::Quad(p0, p1, p2) => {
+                let p0x = px + p0.x * scale;
+                let p0y = py - p0.y * scale;
+                let p1x = px + p1.x * scale;
+                let p1y = py - p1.y * scale;
+                let ex = px + p2.x * scale;
+                let ey = py - p2.y * scale;
+                let c1x = p0x + (2.0 / 3.0) * (p1x - p0x);
+                let c1y = p0y + (2.0 / 3.0) * (p1y - p0y);
+                let c2x = ex + (2.0 / 3.0) * (p1x - ex);
+                let c2y = ey + (2.0 / 3.0) * (p1y - ey);
+                cr.curve_to(
+                    c1x as f64, c1y as f64, c2x as f64, c2y as f64, ex as f64, ey as f64,
+                );
+            }
+            OutlineCurve::Cubic(_, p1, p2, p3) => {
+                cr.curve_to(
+                    (px + p1.x * scale) as f64,
+                    (py - p1.y * scale) as f64,
+                    (px + p2.x * scale) as f64,
+                    (py - p2.y * scale) as f64,
+                    (px + p3.x * scale) as f64,
+                    (py - p3.y * scale) as f64,
+                );
+            }
+        }
+
+        last_end = Some(end);
+    }
+
+    if last_end.is_some() {
+        cr.close_path();
+    }
+}
+
+fn try_draw_emoji_png(
+    cr: &cairo::Context,
+    px: f32,
+    py: f32,
+    em: f32,
+    ch: char,
+) -> Result<bool, CairoError> {
+    let strike = match ratex_unicode_font::emoji_png_raster_for_char(ch, em) {
+        Some(strike) => strike,
+        None => return Ok(false),
+    };
+
+    let ppm = f32::from(strike.pixels_per_em.max(1));
+    let mut scale = em / ppm;
+    let actual_width_em = f32::from(strike.width) / ppm;
+    if actual_width_em > 0.01 && actual_width_em > 1.01 {
+        scale *= 1.0 / actual_width_em;
+    }
+
+    let top_x = px + f32::from(strike.x) * scale;
+    let mut top_y = py - (f32::from(strike.y) + f32::from(strike.height)) * scale;
+    let center_strike = (f32::from(strike.y) + f32::from(strike.height) / 2.0) / ppm;
+    let axis = ratex_font::get_global_metrics(0).axis_height as f32;
+    top_y += (center_strike - axis) * em;
+
+    let mut cursor = Cursor::new(strike.data);
+    let surface = cairo::ImageSurface::create_from_png(&mut cursor)
+        .map_err(|err| CairoError::Cairo(err.to_string()))?;
+
+    cr.save()
+        .map_err(|err| CairoError::Cairo(err.to_string()))?;
+    cr.translate(top_x as f64, top_y as f64);
+    cr.scale(scale as f64, scale as f64);
+    cr.set_source_surface(&surface, 0.0, 0.0)
+        .map_err(|err| CairoError::Cairo(err.to_string()))?;
+    cr.paint()
+        .map_err(|err| CairoError::Cairo(err.to_string()))?;
+    cr.restore()
+        .map_err(|err| CairoError::Cairo(err.to_string()))?;
+    Ok(true)
+}
+
+fn render_line(
+    cr: &cairo::Context,
+    x: f32,
+    y: f32,
+    width: f32,
+    thickness: f32,
+    color: Color,
+    dashed: bool,
+) -> Result<(), CairoError> {
+    let t = thickness.max(0.5);
+    set_source_color(cr, color);
+    if dashed {
+        cr.save()
+            .map_err(|err| CairoError::Cairo(err.to_string()))?;
+        cr.set_line_width(t as f64);
+        cr.set_dash(&[(t * 3.0) as f64, (t * 3.0) as f64], 0.0);
+        cr.move_to(x as f64, y as f64);
+        cr.line_to((x + width) as f64, y as f64);
+        cr.stroke()
+            .map_err(|err| CairoError::Cairo(err.to_string()))?;
+        cr.restore()
+            .map_err(|err| CairoError::Cairo(err.to_string()))?;
+    } else {
+        cr.rectangle(x as f64, (y - t / 2.0) as f64, width as f64, t as f64);
+        cr.fill()
+            .map_err(|err| CairoError::Cairo(err.to_string()))?;
+    }
+    Ok(())
+}
+
+fn render_rect(
+    cr: &cairo::Context,
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+    color: Color,
+) -> Result<(), CairoError> {
+    set_source_color(cr, color);
+    cr.rectangle(
+        x as f64,
+        y as f64,
+        width.max(1.0) as f64,
+        height.max(1.0) as f64,
+    );
+    cr.fill()
+        .map_err(|err| CairoError::Cairo(err.to_string()))?;
+    Ok(())
+}
+
+fn render_path(
+    cr: &cairo::Context,
+    x: f32,
+    y: f32,
+    commands: &[PathCommand],
+    fill: bool,
+    color: Color,
+    em: f32,
+) -> Result<(), CairoError> {
+    set_source_color(cr, color);
+    if fill {
+        let mut start = 0;
+        for i in 1..commands.len() {
+            if matches!(commands[i], PathCommand::MoveTo { .. }) {
+                render_path_segment(cr, x, y, &commands[start..i], true, color, em)?;
+                start = i;
+            }
+        }
+        render_path_segment(cr, x, y, &commands[start..], true, color, em)?;
+    } else {
+        render_path_segment(cr, x, y, commands, false, color, em)?;
+    }
+    Ok(())
+}
+
+fn render_path_segment(
+    cr: &cairo::Context,
+    x: f32,
+    y: f32,
+    commands: &[PathCommand],
+    fill: bool,
+    color: Color,
+    em: f32,
+) -> Result<(), CairoError> {
+    cr.new_path();
+    for command in commands {
+        match command {
+            PathCommand::MoveTo { x: cx, y: cy } => {
+                cr.move_to((x + *cx as f32 * em) as f64, (y + *cy as f32 * em) as f64);
+            }
+            PathCommand::LineTo { x: cx, y: cy } => {
+                cr.line_to((x + *cx as f32 * em) as f64, (y + *cy as f32 * em) as f64);
+            }
+            PathCommand::CubicTo {
+                x1,
+                y1,
+                x2,
+                y2,
+                x: cx,
+                y: cy,
+            } => {
+                cr.curve_to(
+                    (x + *x1 as f32 * em) as f64,
+                    (y + *y1 as f32 * em) as f64,
+                    (x + *x2 as f32 * em) as f64,
+                    (y + *y2 as f32 * em) as f64,
+                    (x + *cx as f32 * em) as f64,
+                    (y + *cy as f32 * em) as f64,
+                );
+            }
+            PathCommand::QuadTo {
+                x1,
+                y1,
+                x: cx,
+                y: cy,
+            } => {
+                let start = cr.current_point().unwrap_or((x as f64, y as f64));
+                let start_x = start.0 as f32;
+                let start_y = start.1 as f32;
+                let c1x = start_x + (2.0 / 3.0) * ((x + *x1 as f32 * em) - start_x);
+                let c1y = start_y + (2.0 / 3.0) * ((y + *y1 as f32 * em) - start_y);
+                let end_x = x + *cx as f32 * em;
+                let end_y = y + *cy as f32 * em;
+                let c2x = end_x + (2.0 / 3.0) * ((x + *x1 as f32 * em) - end_x);
+                let c2y = end_y + (2.0 / 3.0) * ((y + *y1 as f32 * em) - end_y);
+                cr.curve_to(
+                    c1x as f64,
+                    c1y as f64,
+                    c2x as f64,
+                    c2y as f64,
+                    end_x as f64,
+                    end_y as f64,
+                );
+            }
+            PathCommand::Close => cr.close_path(),
+        }
+    }
+
+    set_source_color(cr, color);
+    if fill {
+        cr.set_fill_rule(cairo::FillRule::EvenOdd);
+        cr.fill()
+            .map_err(|err| CairoError::Cairo(err.to_string()))?;
+    } else {
+        cr.save()
+            .map_err(|err| CairoError::Cairo(err.to_string()))?;
+        cr.set_line_width(1.5);
+        cr.stroke()
+            .map_err(|err| CairoError::Cairo(err.to_string()))?;
+        cr.restore()
+            .map_err(|err| CairoError::Cairo(err.to_string()))?;
+    }
+    Ok(())
+}
+
+fn set_source_color(cr: &cairo::Context, color: Color) {
+    cr.set_source_rgba(
+        color.r.clamp(0.0, 1.0) as f64,
+        color.g.clamp(0.0, 1.0) as f64,
+        color.b.clamp(0.0, 1.0) as f64,
+        color.a.clamp(0.0, 1.0) as f64,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratex_layout::{layout, to_display_list, LayoutOptions};
+    use ratex_parser::parse;
+
+    #[test]
+    fn render_metrics_include_padding() {
+        let display_list = DisplayList {
+            items: Vec::new(),
+            width: 2.0,
+            height: 1.0,
+            depth: 0.5,
+        };
+        let metrics = measure_display_list(
+            &display_list,
+            &CairoOptions {
+                font_size: 20.0,
+                padding: 3.0,
+                font_dir: None,
+            },
+        );
+
+        assert_eq!(metrics.width, 46.0);
+        assert_eq!(metrics.total_height, 36.0);
+        assert_eq!(metrics.baseline, 23.0);
+    }
+
+    #[test]
+    fn render_simple_formula_to_image_surface() {
+        let ast = parse(r"\frac{1}{2}").expect("formula should parse");
+        let layout = layout(&ast, &LayoutOptions::default());
+        let display_list = to_display_list(&layout);
+        let options = CairoOptions::default();
+        let metrics = measure_display_list(&display_list, &options);
+
+        let surface = cairo::ImageSurface::create(
+            cairo::Format::ARgb32,
+            metrics.width.ceil() as i32,
+            metrics.total_height.ceil() as i32,
+        )
+        .expect("image surface should be created");
+        let cr = cairo::Context::new(&surface).expect("context should be created");
+
+        render_to_cairo(&cr, &display_list, &options).expect("render should succeed");
+    }
+}

--- a/crates/ratex-cairo/src/lib.rs
+++ b/crates/ratex-cairo/src/lib.rs
@@ -86,8 +86,10 @@ pub fn render_to_cairo(
                     .or_insert_with(|| FontId::parse(font).unwrap_or(FontId::MainRegular));
                 render_glyph(
                     cr,
-                    *x as f32 * em + pad,
-                    *y as f32 * em + pad,
+                    Point {
+                        x: *x as f32 * em + pad,
+                        y: *y as f32 * em + pad,
+                    },
                     font_id,
                     *char_code,
                     *color,
@@ -172,8 +174,7 @@ fn sfnt_collection_index(id: FontId) -> u32 {
 
 fn render_glyph(
     cr: &cairo::Context,
-    px: f32,
-    py: f32,
+    point: Point,
     font_id: FontId,
     char_code: u32,
     color: Color,
@@ -191,18 +192,27 @@ fn render_glyph(
     let glyph_id = font.glyph_id(ch);
 
     if glyph_id.0 == 0 {
-        let _ = try_system_unicode_fallback(cr, px, py, ch, color, em, font_cache, false)?;
+        let _ = try_system_unicode_fallback(
+            cr,
+            point,
+            ch,
+            color,
+            em,
+            font_cache,
+            FallbackOptions {
+                skip_main_regular: false,
+            },
+        )?;
         return Ok(());
     }
 
     if font_id == FontId::EmojiFallback {
-        if try_draw_emoji_png(cr, px, py, em, ch)? {
+        if try_draw_emoji_png(cr, point, em, ch)? {
             return Ok(());
         }
         if render_glyph_with_font(
             cr,
-            px,
-            py,
+            point,
             FontGlyph {
                 font_id,
                 font,
@@ -218,8 +228,7 @@ fn render_glyph(
     if font_id == FontId::CjkRegular {
         if render_glyph_with_font(
             cr,
-            px,
-            py,
+            point,
             FontGlyph {
                 font_id,
                 font,
@@ -230,7 +239,7 @@ fn render_glyph(
         )? {
             return Ok(());
         }
-        if try_draw_emoji_or_outline(cr, px, py, ch, color, em, font_cache)? {
+        if try_draw_emoji_or_outline(cr, point, ch, color, em, font_cache)? {
             return Ok(());
         }
         if let Some(fallback_font) = font_cache.get(&FontId::CjkFallback) {
@@ -238,8 +247,7 @@ fn render_glyph(
             if fallback_id.0 != 0 {
                 let _ = render_glyph_with_font(
                     cr,
-                    px,
-                    py,
+                    point,
                     FontGlyph {
                         font_id: FontId::CjkFallback,
                         font: fallback_font,
@@ -256,8 +264,7 @@ fn render_glyph(
     if font_id == FontId::CjkFallback {
         if render_glyph_with_font(
             cr,
-            px,
-            py,
+            point,
             FontGlyph {
                 font_id,
                 font,
@@ -268,14 +275,13 @@ fn render_glyph(
         )? {
             return Ok(());
         }
-        let _ = try_draw_emoji_or_outline(cr, px, py, ch, color, em, font_cache)?;
+        let _ = try_draw_emoji_or_outline(cr, point, ch, color, em, font_cache)?;
         return Ok(());
     }
 
     if render_glyph_with_font(
         cr,
-        px,
-        py,
+        point,
         FontGlyph {
             font_id,
             font,
@@ -288,28 +294,47 @@ fn render_glyph(
     }
 
     let skip_main = font_id == FontId::MainRegular;
-    let _ = try_system_unicode_fallback(cr, px, py, ch, color, em, font_cache, skip_main)?;
+    let _ = try_system_unicode_fallback(
+        cr,
+        point,
+        ch,
+        color,
+        em,
+        font_cache,
+        FallbackOptions {
+            skip_main_regular: skip_main,
+        },
+    )?;
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Point {
+    x: f32,
+    y: f32,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FallbackOptions {
+    skip_main_regular: bool,
 }
 
 fn try_system_unicode_fallback(
     cr: &cairo::Context,
-    px: f32,
-    py: f32,
+    point: Point,
     ch: char,
     color: Color,
     em: f32,
     font_cache: &HashMap<FontId, FontRef<'_>>,
-    skip_main_regular: bool,
+    options: FallbackOptions,
 ) -> Result<bool, CairoError> {
-    if !skip_main_regular {
+    if !options.skip_main_regular {
         if let Some(font) = font_cache.get(&FontId::MainRegular) {
             let glyph_id = font.glyph_id(ch);
             if glyph_id.0 != 0
                 && render_glyph_with_font(
                     cr,
-                    px,
-                    py,
+                    point,
                     FontGlyph {
                         font_id: FontId::MainRegular,
                         font,
@@ -329,8 +354,7 @@ fn try_system_unicode_fallback(
         if glyph_id.0 != 0
             && render_glyph_with_font(
                 cr,
-                px,
-                py,
+                point,
                 FontGlyph {
                     font_id: FontId::CjkRegular,
                     font,
@@ -344,7 +368,7 @@ fn try_system_unicode_fallback(
         }
     }
 
-    if try_draw_emoji_or_outline(cr, px, py, ch, color, em, font_cache)? {
+    if try_draw_emoji_or_outline(cr, point, ch, color, em, font_cache)? {
         return Ok(true);
     }
 
@@ -353,8 +377,7 @@ fn try_system_unicode_fallback(
         if glyph_id.0 != 0
             && render_glyph_with_font(
                 cr,
-                px,
-                py,
+                point,
                 FontGlyph {
                     font_id: FontId::CjkFallback,
                     font,
@@ -373,14 +396,13 @@ fn try_system_unicode_fallback(
 
 fn try_draw_emoji_or_outline(
     cr: &cairo::Context,
-    px: f32,
-    py: f32,
+    point: Point,
     ch: char,
     color: Color,
     em: f32,
     font_cache: &HashMap<FontId, FontRef<'_>>,
 ) -> Result<bool, CairoError> {
-    if try_draw_emoji_png(cr, px, py, em, ch)? {
+    if try_draw_emoji_png(cr, point, em, ch)? {
         return Ok(true);
     }
 
@@ -389,8 +411,7 @@ fn try_draw_emoji_or_outline(
         if glyph_id.0 != 0 {
             return render_glyph_with_font(
                 cr,
-                px,
-                py,
+                point,
                 FontGlyph {
                     font_id: FontId::EmojiFallback,
                     font,
@@ -413,8 +434,7 @@ struct FontGlyph<'a> {
 
 fn render_glyph_with_font(
     cr: &cairo::Context,
-    px: f32,
-    py: f32,
+    point: Point,
     glyph: FontGlyph<'_>,
     color: Color,
     em: f32,
@@ -436,42 +456,47 @@ fn render_glyph_with_font(
     if glyph.font_id == FontId::EmojiFallback {
         let actual_advance = glyph.font.h_advance_unscaled(glyph.glyph_id);
         let actual_advance_em = actual_advance / units_per_em;
-        if actual_advance_em > 0.01 && actual_advance_em > 1.01 {
+        if actual_advance_em > 1.01 {
             scale *= 1.0 / actual_advance_em;
         }
     }
 
-    append_outline_path(cr, &curves, px, py, scale);
+    cr.save()
+        .map_err(|err| CairoError::Cairo(err.to_string()))?;
+    cr.set_fill_rule(cairo::FillRule::Winding);
+    append_outline_path(cr, &curves, point, scale);
     set_source_color(cr, color);
     cr.fill()
+        .map_err(|err| CairoError::Cairo(err.to_string()))?;
+    cr.restore()
         .map_err(|err| CairoError::Cairo(err.to_string()))?;
     Ok(true)
 }
 
-fn append_outline_path(cr: &cairo::Context, curves: &[OutlineCurve], px: f32, py: f32, scale: f32) {
+fn append_outline_path(cr: &cairo::Context, curves: &[OutlineCurve], point: Point, scale: f32) {
     let mut last_end: Option<(f32, f32)> = None;
 
     for curve in curves {
         let (start, end) = match curve {
             OutlineCurve::Line(p0, p1) => {
-                let sx = px + p0.x * scale;
-                let sy = py - p0.y * scale;
-                let ex = px + p1.x * scale;
-                let ey = py - p1.y * scale;
+                let sx = point.x + p0.x * scale;
+                let sy = point.y - p0.y * scale;
+                let ex = point.x + p1.x * scale;
+                let ey = point.y - p1.y * scale;
                 ((sx, sy), (ex, ey))
             }
             OutlineCurve::Quad(p0, _, p2) => {
-                let sx = px + p0.x * scale;
-                let sy = py - p0.y * scale;
-                let ex = px + p2.x * scale;
-                let ey = py - p2.y * scale;
+                let sx = point.x + p0.x * scale;
+                let sy = point.y - p0.y * scale;
+                let ex = point.x + p2.x * scale;
+                let ey = point.y - p2.y * scale;
                 ((sx, sy), (ex, ey))
             }
             OutlineCurve::Cubic(p0, _, _, p3) => {
-                let sx = px + p0.x * scale;
-                let sy = py - p0.y * scale;
-                let ex = px + p3.x * scale;
-                let ey = py - p3.y * scale;
+                let sx = point.x + p0.x * scale;
+                let sy = point.y - p0.y * scale;
+                let ex = point.x + p3.x * scale;
+                let ey = point.y - p3.y * scale;
                 ((sx, sy), (ex, ey))
             }
         };
@@ -490,15 +515,18 @@ fn append_outline_path(cr: &cairo::Context, curves: &[OutlineCurve], px: f32, py
 
         match curve {
             OutlineCurve::Line(_, p1) => {
-                cr.line_to((px + p1.x * scale) as f64, (py - p1.y * scale) as f64);
+                cr.line_to(
+                    (point.x + p1.x * scale) as f64,
+                    (point.y - p1.y * scale) as f64,
+                );
             }
             OutlineCurve::Quad(p0, p1, p2) => {
-                let p0x = px + p0.x * scale;
-                let p0y = py - p0.y * scale;
-                let p1x = px + p1.x * scale;
-                let p1y = py - p1.y * scale;
-                let ex = px + p2.x * scale;
-                let ey = py - p2.y * scale;
+                let p0x = point.x + p0.x * scale;
+                let p0y = point.y - p0.y * scale;
+                let p1x = point.x + p1.x * scale;
+                let p1y = point.y - p1.y * scale;
+                let ex = point.x + p2.x * scale;
+                let ey = point.y - p2.y * scale;
                 let c1x = p0x + (2.0 / 3.0) * (p1x - p0x);
                 let c1y = p0y + (2.0 / 3.0) * (p1y - p0y);
                 let c2x = ex + (2.0 / 3.0) * (p1x - ex);
@@ -509,12 +537,12 @@ fn append_outline_path(cr: &cairo::Context, curves: &[OutlineCurve], px: f32, py
             }
             OutlineCurve::Cubic(_, p1, p2, p3) => {
                 cr.curve_to(
-                    (px + p1.x * scale) as f64,
-                    (py - p1.y * scale) as f64,
-                    (px + p2.x * scale) as f64,
-                    (py - p2.y * scale) as f64,
-                    (px + p3.x * scale) as f64,
-                    (py - p3.y * scale) as f64,
+                    (point.x + p1.x * scale) as f64,
+                    (point.y - p1.y * scale) as f64,
+                    (point.x + p2.x * scale) as f64,
+                    (point.y - p2.y * scale) as f64,
+                    (point.x + p3.x * scale) as f64,
+                    (point.y - p3.y * scale) as f64,
                 );
             }
         }
@@ -529,8 +557,7 @@ fn append_outline_path(cr: &cairo::Context, curves: &[OutlineCurve], px: f32, py
 
 fn try_draw_emoji_png(
     cr: &cairo::Context,
-    px: f32,
-    py: f32,
+    point: Point,
     em: f32,
     ch: char,
 ) -> Result<bool, CairoError> {
@@ -542,12 +569,12 @@ fn try_draw_emoji_png(
     let ppm = f32::from(strike.pixels_per_em.max(1));
     let mut scale = em / ppm;
     let actual_width_em = f32::from(strike.width) / ppm;
-    if actual_width_em > 0.01 && actual_width_em > 1.01 {
+    if actual_width_em > 1.01 {
         scale *= 1.0 / actual_width_em;
     }
 
-    let top_x = px + f32::from(strike.x) * scale;
-    let mut top_y = py - (f32::from(strike.y) + f32::from(strike.height)) * scale;
+    let top_x = point.x + f32::from(strike.x) * scale;
+    let mut top_y = point.y - (f32::from(strike.y) + f32::from(strike.height)) * scale;
     let center_strike = (f32::from(strike.y) + f32::from(strike.height) / 2.0) / ppm;
     let axis = ratex_font::get_global_metrics(0).axis_height as f32;
     top_y += (center_strike - axis) * em;

--- a/crates/ratex-gtk4/Cargo.toml
+++ b/crates/ratex-gtk4/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ratex-gtk4"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "GTK4 widget for native RaTeX rendering"
+
+[dependencies]
+ratex-cairo = { workspace = true }
+ratex-layout = { workspace = true }
+ratex-parser = { workspace = true }
+ratex-types = { workspace = true }
+gtk4 = "0.9"
+
+[[example]]
+name = "formula_demo"
+path = "examples/formula_demo.rs"

--- a/crates/ratex-gtk4/Cargo.toml
+++ b/crates/ratex-gtk4/Cargo.toml
@@ -8,6 +8,9 @@ homepage.workspace = true
 documentation.workspace = true
 description = "GTK4 widget for native RaTeX rendering"
 
+[lib]
+crate-type = ["rlib", "cdylib"]
+
 [dependencies]
 ratex-cairo = { workspace = true }
 ratex-layout = { workspace = true }
@@ -15,6 +18,13 @@ ratex-parser = { workspace = true }
 ratex-types = { workspace = true }
 gtk4 = "0.9"
 
+[dev-dependencies]
+libadwaita = { version = "0.7", features = ["v1_4"] }
+
 [[example]]
 name = "formula_demo"
 path = "examples/formula_demo.rs"
+
+[[example]]
+name = "adw_formula_demo"
+path = "examples/adw_formula_demo.rs"

--- a/crates/ratex-gtk4/examples/adw_formula_demo.rs
+++ b/crates/ratex-gtk4/examples/adw_formula_demo.rs
@@ -1,0 +1,115 @@
+use gtk4::prelude::*;
+use gtk4::{Align, CheckButton, DropDown, Entry, Label, Orientation, SpinButton, StringList};
+use libadwaita::{Application, ApplicationWindow, Clamp, HeaderBar, StyleManager, ToolbarView};
+use ratex_gtk4::RatexFormula;
+
+fn main() {
+    let app = Application::builder()
+        .application_id("io.ratex.demo.gtk4.adwaita")
+        .build();
+    app.connect_activate(build_ui);
+    app.run();
+}
+
+fn build_ui(app: &Application) {
+    let style_manager = StyleManager::default();
+
+    let formula = RatexFormula::new();
+    formula.set_hexpand(true);
+    formula.set_vexpand(true);
+    formula.set_halign(Align::Start);
+    formula.set_valign(Align::Start);
+    formula.set_latex(r"\int_0^\infty e^{-x^2} dx = \frac{\sqrt{\pi}}{2}");
+    formula.set_font_size(36.0);
+    formula.set_margin_top(12);
+
+    let entry = Entry::builder()
+        .hexpand(true)
+        .text(r"\int_0^\infty e^{-x^2} dx = \frac{\sqrt{\pi}}{2}")
+        .build();
+    {
+        let formula = formula.clone();
+        entry.connect_changed(move |entry| {
+            formula.set_latex(entry.text().as_ref());
+        });
+    }
+
+    let display_mode = CheckButton::builder()
+        .label("Display mode")
+        .active(true)
+        .build();
+    {
+        let formula = formula.clone();
+        display_mode.connect_toggled(move |button| {
+            formula.set_display_mode(button.is_active());
+        });
+    }
+
+    let font_size = SpinButton::with_range(8.0, 128.0, 1.0);
+    font_size.set_value(36.0);
+    {
+        let formula = formula.clone();
+        font_size.connect_value_changed(move |spin| {
+            formula.set_font_size(spin.value());
+        });
+    }
+
+    let appearance = DropDown::new(
+        Some(StringList::new(&["System", "Light", "Dark"])),
+        None::<gtk4::Expression>,
+    );
+    appearance.set_selected(0);
+    appearance.connect_selected_notify(move |dropdown| match dropdown.selected() {
+        1 => style_manager.set_color_scheme(libadwaita::ColorScheme::ForceLight),
+        2 => style_manager.set_color_scheme(libadwaita::ColorScheme::ForceDark),
+        _ => style_manager.set_color_scheme(libadwaita::ColorScheme::Default),
+    });
+
+    let error_label = Label::new(None);
+    error_label.set_halign(Align::Start);
+    error_label.add_css_class("error");
+    {
+        let formula = formula.clone();
+        let error_label = error_label.clone();
+        formula.connect_notify_local(Some("error-message"), move |formula, _| {
+            error_label.set_text(formula.error_message().as_deref().unwrap_or(""));
+        });
+    }
+
+    let controls = gtk4::Box::builder()
+        .orientation(Orientation::Horizontal)
+        .spacing(12)
+        .build();
+    controls.append(&display_mode);
+    controls.append(&Label::new(Some("Font size")));
+    controls.append(&font_size);
+    controls.append(&Label::new(Some("Appearance")));
+    controls.append(&appearance);
+
+    let content = gtk4::Box::builder()
+        .orientation(Orientation::Vertical)
+        .spacing(12)
+        .margin_top(24)
+        .margin_bottom(24)
+        .margin_start(24)
+        .margin_end(24)
+        .build();
+    content.append(&entry);
+    content.append(&controls);
+    content.append(&formula);
+    content.append(&error_label);
+
+    let clamp = Clamp::builder().maximum_size(900).child(&content).build();
+    let toolbar_view = ToolbarView::new();
+    toolbar_view.add_top_bar(&HeaderBar::new());
+    toolbar_view.set_content(Some(&clamp));
+
+    let window = ApplicationWindow::builder()
+        .application(app)
+        .title("RaTeX GTK4 Adwaita Demo")
+        .default_width(960)
+        .default_height(420)
+        .content(&toolbar_view)
+        .build();
+    window.present();
+}

--- a/crates/ratex-gtk4/examples/formula_demo.rs
+++ b/crates/ratex-gtk4/examples/formula_demo.rs
@@ -1,0 +1,96 @@
+use gtk4::prelude::*;
+use gtk4::{
+    Align, Application, ApplicationWindow, Box as GtkBox, CheckButton, Entry, Label, Orientation,
+    SpinButton,
+};
+use ratex_gtk4::RatexFormula;
+
+fn main() {
+    let app = Application::builder()
+        .application_id("io.ratex.demo.gtk4")
+        .build();
+    app.connect_activate(build_ui);
+    app.run();
+}
+
+fn build_ui(app: &Application) {
+    let formula = RatexFormula::new();
+    formula.set_hexpand(true);
+    formula.set_vexpand(true);
+    formula.set_halign(Align::Start);
+    formula.set_valign(Align::Start);
+    formula.set_latex(r"\int_0^\infty e^{-x^2} dx = \frac{\sqrt{\pi}}{2}");
+    formula.set_font_size(36.0);
+    formula.set_margin_top(12);
+
+    let entry = Entry::builder()
+        .hexpand(true)
+        .text(r"\int_0^\infty e^{-x^2} dx = \frac{\sqrt{\pi}}{2}")
+        .build();
+    {
+        let formula = formula.clone();
+        entry.connect_changed(move |entry| {
+            formula.set_latex(entry.text().as_ref());
+        });
+    }
+
+    let display_mode = CheckButton::builder()
+        .label("Display mode")
+        .active(true)
+        .build();
+    {
+        let formula = formula.clone();
+        display_mode.connect_toggled(move |button| {
+            formula.set_display_mode(button.is_active());
+        });
+    }
+
+    let font_size = SpinButton::with_range(8.0, 128.0, 1.0);
+    font_size.set_value(36.0);
+    {
+        let formula = formula.clone();
+        font_size.connect_value_changed(move |spin| {
+            formula.set_font_size(spin.value());
+        });
+    }
+
+    let error_label = Label::new(None);
+    error_label.set_halign(Align::Start);
+    {
+        let formula = formula.clone();
+        let error_label = error_label.clone();
+        formula.connect_notify_local(Some("error-message"), move |formula, _| {
+            error_label.set_text(formula.error_message().as_deref().unwrap_or(""));
+        });
+    }
+
+    let controls = GtkBox::builder()
+        .orientation(Orientation::Horizontal)
+        .spacing(12)
+        .build();
+    controls.append(&display_mode);
+    controls.append(&Label::new(Some("Font size")));
+    controls.append(&font_size);
+
+    let content = GtkBox::builder()
+        .orientation(Orientation::Vertical)
+        .spacing(12)
+        .margin_top(24)
+        .margin_bottom(24)
+        .margin_start(24)
+        .margin_end(24)
+        .build();
+    content.append(&entry);
+    content.append(&controls);
+    content.append(&formula);
+    content.append(&error_label);
+
+    let window = ApplicationWindow::builder()
+        .application(app)
+        .title("RaTeX GTK4 Demo")
+        .default_width(900)
+        .default_height(400)
+        .child(&content)
+        .build();
+    window.present();
+}

--- a/crates/ratex-gtk4/src/imp.rs
+++ b/crates/ratex-gtk4/src/imp.rs
@@ -1,0 +1,336 @@
+use std::cell::RefCell;
+use std::path::PathBuf;
+use std::sync::LazyLock;
+
+use gtk::gdk;
+use gtk::glib;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+use gtk4 as gtk;
+use ratex_cairo::{measure_display_list, render_to_cairo, CairoOptions, RenderMetrics};
+use ratex_layout::{layout, to_display_list, LayoutOptions};
+use ratex_parser::parse;
+use ratex_types::{Color, DisplayList, MathStyle};
+
+#[derive(Debug, Clone, Copy)]
+pub struct FormulaMetrics {
+    pub width: i32,
+    pub height: i32,
+    pub baseline: i32,
+}
+
+impl Default for FormulaMetrics {
+    fn default() -> Self {
+        Self {
+            width: 1,
+            height: 1,
+            baseline: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FormulaState {
+    latex: String,
+    display_mode: bool,
+    font_size: f64,
+    padding: f64,
+    color: Option<gdk::RGBA>,
+    font_dir: Option<PathBuf>,
+    display_list: Option<DisplayList>,
+    error_message: Option<String>,
+    metrics: FormulaMetrics,
+}
+
+impl Default for FormulaState {
+    fn default() -> Self {
+        Self {
+            latex: String::new(),
+            display_mode: true,
+            font_size: 24.0,
+            padding: 4.0,
+            color: None,
+            font_dir: None,
+            display_list: None,
+            error_message: None,
+            metrics: FormulaMetrics::default(),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct RatexFormula {
+    state: RefCell<FormulaState>,
+}
+
+#[glib::object_subclass]
+impl ObjectSubclass for RatexFormula {
+    const NAME: &'static str = "RaTeXFormula";
+    type Type = super::RatexFormula;
+    type ParentType = gtk::Widget;
+}
+
+impl ObjectImpl for RatexFormula {
+    fn constructed(&self) {
+        self.parent_constructed();
+        self.relayout();
+    }
+
+    fn properties() -> &'static [glib::ParamSpec] {
+        static PROPERTIES: LazyLock<Vec<glib::ParamSpec>> = LazyLock::new(|| {
+            vec![
+                glib::ParamSpecString::builder("latex")
+                    .explicit_notify()
+                    .build(),
+                glib::ParamSpecBoolean::builder("display-mode")
+                    .default_value(true)
+                    .explicit_notify()
+                    .build(),
+                glib::ParamSpecDouble::builder("font-size")
+                    .minimum(1.0)
+                    .maximum(4096.0)
+                    .default_value(24.0)
+                    .explicit_notify()
+                    .build(),
+                glib::ParamSpecDouble::builder("padding")
+                    .minimum(0.0)
+                    .maximum(512.0)
+                    .default_value(4.0)
+                    .explicit_notify()
+                    .build(),
+                glib::ParamSpecBoxed::builder::<gdk::RGBA>("color")
+                    .explicit_notify()
+                    .build(),
+                glib::ParamSpecString::builder("font-dir")
+                    .explicit_notify()
+                    .build(),
+                glib::ParamSpecString::builder("error-message")
+                    .read_only()
+                    .build(),
+            ]
+        });
+        PROPERTIES.as_ref()
+    }
+
+    fn set_property(&self, id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
+        let mut state = self.state.borrow_mut();
+        let mut relayout = false;
+        match pspec.name() {
+            "latex" => {
+                let latex = value
+                    .get::<String>()
+                    .expect("latex property should be a string");
+                if state.latex != latex {
+                    state.latex = latex;
+                    relayout = true;
+                }
+            }
+            "display-mode" => {
+                let display_mode = value
+                    .get::<bool>()
+                    .expect("display-mode property should be a bool");
+                if state.display_mode != display_mode {
+                    state.display_mode = display_mode;
+                    relayout = true;
+                }
+            }
+            "font-size" => {
+                let font_size = value
+                    .get::<f64>()
+                    .expect("font-size property should be a double");
+                if (state.font_size - font_size).abs() > f64::EPSILON {
+                    state.font_size = font_size;
+                    relayout = true;
+                }
+            }
+            "padding" => {
+                let padding = value
+                    .get::<f64>()
+                    .expect("padding property should be a double");
+                if (state.padding - padding).abs() > f64::EPSILON {
+                    state.padding = padding;
+                    relayout = true;
+                }
+            }
+            "color" => {
+                let color = value
+                    .get::<Option<gdk::RGBA>>()
+                    .expect("color property should be an RGBA or None");
+                if state.color != color {
+                    state.color = color;
+                    relayout = true;
+                }
+            }
+            "font-dir" => {
+                let font_dir = value
+                    .get::<Option<String>>()
+                    .expect("font-dir property should be a string or None")
+                    .map(PathBuf::from);
+                if state.font_dir != font_dir {
+                    state.font_dir = font_dir;
+                    relayout = true;
+                }
+            }
+            _ => unreachable!("unknown property {id}"),
+        }
+        drop(state);
+
+        if relayout {
+            self.relayout();
+            self.obj().notify(pspec.name());
+        }
+    }
+
+    fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+        let state = self.state.borrow();
+        match pspec.name() {
+            "latex" => state.latex.to_value(),
+            "display-mode" => state.display_mode.to_value(),
+            "font-size" => state.font_size.to_value(),
+            "padding" => state.padding.to_value(),
+            "color" => state.color.to_value(),
+            "font-dir" => state
+                .font_dir
+                .as_ref()
+                .map(|path| path.to_string_lossy().into_owned())
+                .to_value(),
+            "error-message" => state.error_message.to_value(),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl WidgetImpl for RatexFormula {
+    fn request_mode(&self) -> gtk::SizeRequestMode {
+        gtk::SizeRequestMode::ConstantSize
+    }
+
+    fn measure(&self, orientation: gtk::Orientation, _for_size: i32) -> (i32, i32, i32, i32) {
+        let metrics = self.state.borrow().metrics;
+        match orientation {
+            gtk::Orientation::Horizontal => (metrics.width, metrics.width, -1, -1),
+            gtk::Orientation::Vertical => (
+                metrics.height,
+                metrics.height,
+                metrics.baseline,
+                metrics.baseline,
+            ),
+            _ => (1, 1, -1, -1),
+        }
+    }
+
+    fn snapshot(&self, snapshot: &gtk::Snapshot) {
+        let obj = self.obj();
+        let width = obj.width().max(1) as f32;
+        let height = obj.height().max(1) as f32;
+        let bounds = gtk::graphene::Rect::new(0.0, 0.0, width, height);
+        let cr = snapshot.append_cairo(&bounds);
+
+        let state = self.state.borrow();
+        let Some(display_list) = state.display_list.as_ref() else {
+            return;
+        };
+
+        let options = CairoOptions {
+            font_size: state.font_size,
+            padding: state.padding,
+            font_dir: state.font_dir.clone(),
+        };
+        let _ = render_to_cairo(&cr, display_list, &options);
+    }
+}
+
+impl RatexFormula {
+    pub fn metrics(&self) -> RenderMetrics {
+        let state = self.state.borrow();
+        RenderMetrics {
+            width: state.metrics.width as f64,
+            total_height: state.metrics.height as f64,
+            baseline: state.metrics.baseline as f64,
+        }
+    }
+
+    fn relayout(&self) {
+        let obj = self.obj();
+        let old_metrics = self.state.borrow().metrics;
+
+        let mut state = self.state.borrow_mut();
+        let result = layout_formula(
+            &state.latex,
+            state.display_mode,
+            state.color,
+            state.font_size,
+            state.padding,
+            state.font_dir.clone(),
+        );
+
+        match result {
+            Ok((display_list, metrics)) => {
+                state.display_list = Some(display_list);
+                state.error_message = None;
+                state.metrics = metrics;
+            }
+            Err(message) => {
+                state.display_list = None;
+                state.error_message = Some(message);
+                state.metrics = FormulaMetrics::default();
+            }
+        }
+
+        let metrics_changed = state.metrics.width != old_metrics.width
+            || state.metrics.height != old_metrics.height
+            || state.metrics.baseline != old_metrics.baseline;
+        drop(state);
+
+        if metrics_changed {
+            obj.queue_resize();
+        }
+        obj.queue_draw();
+        obj.notify("error-message");
+    }
+}
+
+fn layout_formula(
+    latex: &str,
+    display_mode: bool,
+    color: Option<gdk::RGBA>,
+    font_size: f64,
+    padding: f64,
+    font_dir: Option<PathBuf>,
+) -> Result<(DisplayList, FormulaMetrics), String> {
+    if latex.trim().is_empty() {
+        return Ok((DisplayList::default(), FormulaMetrics::default()));
+    }
+
+    let ast = parse(latex).map_err(|err| format!("Parse error: {err}"))?;
+    let style = if display_mode {
+        MathStyle::Display
+    } else {
+        MathStyle::Text
+    };
+    let color = color.map(color_from_rgba).unwrap_or(Color::BLACK);
+    let layout_options = LayoutOptions::default().with_style(style).with_color(color);
+    let layout_box = layout(&ast, &layout_options);
+    let display_list = to_display_list(&layout_box);
+    let metrics = measure_display_list(
+        &display_list,
+        &CairoOptions {
+            font_size,
+            padding,
+            font_dir,
+        },
+    );
+
+    Ok((
+        display_list,
+        FormulaMetrics {
+            width: metrics.width.ceil() as i32,
+            height: metrics.total_height.ceil() as i32,
+            baseline: metrics.baseline.round() as i32,
+        },
+    ))
+}
+
+fn color_from_rgba(rgba: gdk::RGBA) -> Color {
+    Color::new(rgba.red(), rgba.green(), rgba.blue(), rgba.alpha())
+}

--- a/crates/ratex-gtk4/src/imp.rs
+++ b/crates/ratex-gtk4/src/imp.rs
@@ -38,6 +38,7 @@ struct FormulaState {
     color: Option<gdk::RGBA>,
     font_dir: Option<PathBuf>,
     display_list: Option<DisplayList>,
+    themed_display_list: Option<(Color, DisplayList)>,
     error_message: Option<String>,
     metrics: FormulaMetrics,
 }
@@ -52,6 +53,7 @@ impl Default for FormulaState {
             color: None,
             font_dir: None,
             display_list: None,
+            themed_display_list: None,
             error_message: None,
             metrics: FormulaMetrics::default(),
         }
@@ -226,17 +228,39 @@ impl WidgetImpl for RatexFormula {
         let bounds = gtk::graphene::Rect::new(0.0, 0.0, width, height);
         let cr = snapshot.append_cairo(&bounds);
 
-        let state = self.state.borrow();
-        let Some(display_list) = state.display_list.as_ref() else {
-            return;
-        };
-
+        let mut state = self.state.borrow_mut();
         let options = CairoOptions {
             font_size: state.font_size,
             padding: state.padding,
             font_dir: state.font_dir.clone(),
         };
-        let _ = render_to_cairo(&cr, display_list, &options);
+        let render_list = if state.color.is_none() {
+            let theme_color = color_from_rgba(obj.style_context().color());
+            let needs_relayout = !matches!(
+                state.themed_display_list.as_ref(),
+                Some((cached_color, _)) if *cached_color == theme_color
+            );
+            if needs_relayout {
+                if let Ok(display_list) =
+                    layout_display_list(&state.latex, state.display_mode, theme_color)
+                {
+                    state.themed_display_list = Some((theme_color, display_list));
+                }
+            }
+            state
+                .themed_display_list
+                .as_ref()
+                .map(|(_, display_list)| display_list)
+                .or(state.display_list.as_ref())
+        } else {
+            state.display_list.as_ref()
+        };
+        let Some(render_list) = render_list.cloned() else {
+            return;
+        };
+        drop(state);
+
+        let _ = render_to_cairo(&cr, &render_list, &options);
     }
 }
 
@@ -267,11 +291,13 @@ impl RatexFormula {
         match result {
             Ok((display_list, metrics)) => {
                 state.display_list = Some(display_list);
+                state.themed_display_list = None;
                 state.error_message = None;
                 state.metrics = metrics;
             }
             Err(message) => {
                 state.display_list = None;
+                state.themed_display_list = None;
                 state.error_message = Some(message);
                 state.metrics = FormulaMetrics::default();
             }
@@ -302,16 +328,8 @@ fn layout_formula(
         return Ok((DisplayList::default(), FormulaMetrics::default()));
     }
 
-    let ast = parse(latex).map_err(|err| format!("Parse error: {err}"))?;
-    let style = if display_mode {
-        MathStyle::Display
-    } else {
-        MathStyle::Text
-    };
     let color = color.map(color_from_rgba).unwrap_or(Color::BLACK);
-    let layout_options = LayoutOptions::default().with_style(style).with_color(color);
-    let layout_box = layout(&ast, &layout_options);
-    let display_list = to_display_list(&layout_box);
+    let display_list = layout_display_list(latex, display_mode, color)?;
     let metrics = measure_display_list(
         &display_list,
         &CairoOptions {
@@ -331,6 +349,55 @@ fn layout_formula(
     ))
 }
 
+fn layout_display_list(
+    latex: &str,
+    display_mode: bool,
+    default_color: Color,
+) -> Result<DisplayList, String> {
+    if latex.trim().is_empty() {
+        return Ok(DisplayList::default());
+    }
+
+    let ast = parse(latex).map_err(|err| format!("Parse error: {err}"))?;
+    let style = if display_mode {
+        MathStyle::Display
+    } else {
+        MathStyle::Text
+    };
+    let layout_options = LayoutOptions::default()
+        .with_style(style)
+        .with_color(default_color);
+    let layout_box = layout(&ast, &layout_options);
+    Ok(to_display_list(&layout_box))
+}
+
 fn color_from_rgba(rgba: gdk::RGBA) -> Color {
     Color::new(rgba.red(), rgba.green(), rgba.blue(), rgba.alpha())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratex_types::DisplayItem;
+
+    #[test]
+    fn default_color_does_not_override_explicit_black() {
+        let theme_color = Color::rgb(1.0, 0.0, 0.0);
+        let display_list = layout_display_list(r"x + \textcolor{black}{y}", true, theme_color)
+            .expect("formula should layout");
+
+        let colors: Vec<Color> = display_list
+            .items
+            .iter()
+            .map(|item| match item {
+                DisplayItem::GlyphPath { color, .. }
+                | DisplayItem::Line { color, .. }
+                | DisplayItem::Rect { color, .. }
+                | DisplayItem::Path { color, .. } => *color,
+            })
+            .collect();
+
+        assert!(colors.contains(&theme_color));
+        assert!(colors.contains(&Color::BLACK));
+    }
 }

--- a/crates/ratex-gtk4/src/lib.rs
+++ b/crates/ratex-gtk4/src/lib.rs
@@ -1,0 +1,87 @@
+mod imp;
+
+use std::path::PathBuf;
+
+use gtk::gdk;
+use gtk::glib;
+use gtk::prelude::*;
+use gtk::subclass::prelude::ObjectSubclassIsExt;
+use gtk4 as gtk;
+
+glib::wrapper! {
+    pub struct RatexFormula(ObjectSubclass<imp::RatexFormula>)
+        @extends gtk::Widget,
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
+}
+
+impl RatexFormula {
+    pub fn new() -> Self {
+        glib::Object::builder().build()
+    }
+
+    pub fn latex(&self) -> String {
+        self.property::<String>("latex")
+    }
+
+    pub fn set_latex(&self, latex: &str) {
+        self.set_property("latex", latex);
+    }
+
+    pub fn display_mode(&self) -> bool {
+        self.property::<bool>("display-mode")
+    }
+
+    pub fn set_display_mode(&self, display_mode: bool) {
+        self.set_property("display-mode", display_mode);
+    }
+
+    pub fn font_size(&self) -> f64 {
+        self.property::<f64>("font-size")
+    }
+
+    pub fn set_font_size(&self, font_size: f64) {
+        self.set_property("font-size", font_size);
+    }
+
+    pub fn padding(&self) -> f64 {
+        self.property::<f64>("padding")
+    }
+
+    pub fn set_padding(&self, padding: f64) {
+        self.set_property("padding", padding);
+    }
+
+    pub fn color(&self) -> Option<gdk::RGBA> {
+        self.property::<Option<gdk::RGBA>>("color")
+    }
+
+    pub fn set_color(&self, color: Option<&gdk::RGBA>) {
+        self.set_property("color", color.cloned());
+    }
+
+    pub fn font_dir(&self) -> Option<PathBuf> {
+        self.property::<Option<String>>("font-dir")
+            .map(PathBuf::from)
+    }
+
+    pub fn set_font_dir(&self, font_dir: Option<&std::path::Path>) {
+        let value = font_dir.map(|path| path.to_string_lossy().into_owned());
+        self.set_property("font-dir", value);
+    }
+
+    pub fn error_message(&self) -> Option<String> {
+        self.property::<Option<String>>("error-message")
+    }
+
+    pub fn baseline_px(&self) -> f64 {
+        self.imp().metrics().baseline
+    }
+}
+
+impl Default for RatexFormula {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub use imp::FormulaMetrics;

--- a/crates/ratex-gtk4/src/lib.rs
+++ b/crates/ratex-gtk4/src/lib.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use gtk::gdk;
 use gtk::glib;
+use gtk::glib::translate::{IntoGlib, IntoGlibPtr};
 use gtk::prelude::*;
 use gtk::subclass::prelude::ObjectSubclassIsExt;
 use gtk4 as gtk;
@@ -85,3 +86,36 @@ impl Default for RatexFormula {
 }
 
 pub use imp::FormulaMetrics;
+
+fn ensure_gtk_initialized_for_c() -> bool {
+    if gtk::is_initialized_main_thread() {
+        return true;
+    }
+
+    unsafe {
+        if gtk::glib::translate::from_glib::<_, bool>(gtk::ffi::gtk_is_initialized()) {
+            // C/GI applications initialize GTK themselves. Bridge that state into gtk-rs
+            // without taking ownership of application initialization here.
+            gtk::set_initialized();
+            return true;
+        }
+    }
+
+    false
+}
+
+#[no_mangle]
+pub extern "C" fn ratex_formula_get_type() -> glib::ffi::GType {
+    if !ensure_gtk_initialized_for_c() {
+        return 0;
+    }
+    RatexFormula::static_type().into_glib()
+}
+
+#[no_mangle]
+pub extern "C" fn ratex_formula_new() -> *mut gtk::ffi::GtkWidget {
+    if !ensure_gtk_initialized_for_c() {
+        return std::ptr::null_mut();
+    }
+    unsafe { RatexFormula::new().upcast::<gtk::Widget>().into_glib_ptr() }
+}

--- a/crates/ratex-pdf/tests/smoke.rs
+++ b/crates/ratex-pdf/tests/smoke.rs
@@ -94,7 +94,7 @@ fn zero_padding_pdf_media_box_keeps_vertical_antialias_guard() {
 
 #[test]
 #[cfg(not(feature = "embed-fonts"))]
-fn missing_font_dir_returns_font_error() {
+fn missing_font_dir_returns_font_error_unless_fonts_are_unified() {
     let nodes = parse("x").expect("parse LaTeX");
     let lbox = layout(
         &nodes,
@@ -105,11 +105,16 @@ fn missing_font_dir_returns_font_error() {
         font_dir: "/definitely/not/a/ratex/font/dir".to_string(),
         ..Default::default()
     };
-    let err = render_to_pdf(&list, &opts).expect_err("bad font_dir must fail");
-    assert!(
-        err.to_string().contains("Missing required font"),
-        "unexpected error: {err}"
-    );
+    match render_to_pdf(&list, &opts) {
+        Ok(pdf) => assert!(
+            pdf.starts_with(b"%PDF-"),
+            "embedded-font feature unification should still render a valid PDF"
+        ),
+        Err(err) => assert!(
+            err.to_string().contains("Missing required font"),
+            "unexpected error: {err}"
+        ),
+    }
 }
 
 /// Color emoji in PDF: `EmojiFallback` → image XObjects (sbix PNG), not empty outlines.

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -30,6 +30,8 @@ RaTeX/
 │   ├── ratex-katex-fonts/        # KaTeX TTF blobs for embed-fonts (crates.io–safe path)
 │   ├── ratex-font-loader/        # Shared lazy font loading/cache for PNG/SVG/PDF
 │   ├── ratex-ffi/                # C ABI: LaTeX → DisplayList JSON (+ Android JNI)
+│   ├── ratex-cairo/              # DisplayList → Cairo context (native Linux / GTK base)
+│   ├── ratex-gtk4/               # GTK4 widget subclass for native Linux rendering
 │   ├── ratex-render/             # DisplayList → PNG (tiny-skia, server-side)
 │   ├── ratex-wasm/               # WASM: LaTeX → DisplayList JSON (browser)
 │   ├── ratex-svg/                # SVG export: DisplayList → SVG string (vector output)
@@ -39,6 +41,7 @@ RaTeX/
 ├── platforms/
 │   ├── ios/                      # Swift + XCFramework + CoreGraphics
 │   ├── android/                  # Kotlin + AAR + JNI/Canvas
+│   ├── gtk/                      # GTK4 Linux docs / examples / future GI packaging notes
 │   ├── flutter/                  # Dart FFI + widget
 │   ├── react-native/             # Native module + iOS/Android views
 │   └── web/                      # npm package `ratex-wasm`: WASM + TypeScript web-render

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -41,7 +41,7 @@ RaTeX/
 ├── platforms/
 │   ├── ios/                      # Swift + XCFramework + CoreGraphics
 │   ├── android/                  # Kotlin + AAR + JNI/Canvas
-│   ├── gtk/                      # GTK4 Linux docs / examples / future GI packaging notes
+│   ├── gtk/                      # GTK4 Linux docs, C/GI metadata, and C/Python/Vala examples
 │   ├── flutter/                  # Dart FFI + widget
 │   ├── react-native/             # Native module + iOS/Android views
 │   └── web/                      # npm package `ratex-wasm`: WASM + TypeScript web-render
@@ -293,6 +293,8 @@ ratex-layout
     ↑
 platforms/ (ios, android, flutter, react-native, web)
 ```
+
+`platforms/gtk` contains the Linux desktop GObject package metadata for the `RatexGtk-1.0` namespace: the public C header, GIR file, Vala VAPI, pkg-config template, and C/Python/Vala smoke examples. The implementation lives in `crates/ratex-gtk4`.
 
 ---
 

--- a/platforms/gtk/README.md
+++ b/platforms/gtk/README.md
@@ -1,0 +1,52 @@
+# GTK4 Linux Support
+
+This repository now includes an early native GTK4 integration for Linux:
+
+- `crates/ratex-cairo` renders a RaTeX `DisplayList` into a Cairo context.
+- `crates/ratex-gtk4` provides a `RatexFormula` GTK4 widget implemented as a real `GtkWidget` subclass.
+
+This first pass is intentionally small and boring:
+
+- bundled KaTeX fonts by default
+- optional `font-dir` override
+- synchronous parse/layout on property changes
+- manual test example before GObject Introspection packaging work
+
+## Run the example
+
+Install GTK4 development packages first.
+
+On Debian / Ubuntu:
+
+```bash
+sudo apt-get install -y libgtk-4-dev libcairo2-dev
+```
+
+From the repository root:
+
+```bash
+cargo run -p ratex-gtk4 --example formula_demo
+```
+
+The demo window includes:
+
+- a LaTeX entry field
+- a display-mode toggle
+- a font-size spinner
+- a live `RatexFormula` widget
+
+## Current scope
+
+Implemented now:
+
+- Cairo renderer for `DisplayList`
+- GTK4 widget subclass with measurement and snapshot drawing
+- bundled-font default behavior
+- local runnable example
+
+Planned next:
+
+- theme-derived default foreground color
+- GObject Introspection (`.gir` / `.typelib`)
+- C, Python, and Vala smoke examples
+- CI coverage for GTK/GI tooling

--- a/platforms/gtk/README.md
+++ b/platforms/gtk/README.md
@@ -10,7 +10,8 @@ This first pass is intentionally small and boring:
 - bundled KaTeX fonts by default
 - optional `font-dir` override
 - synchronous parse/layout on property changes
-- manual test example before GObject Introspection packaging work
+- Rust, C, Python, and Vala smoke examples
+- GObject Introspection namespace: `RatexGtk-1.0`
 
 ## Run the example
 
@@ -19,16 +20,41 @@ Install GTK4 development packages first.
 On Debian / Ubuntu:
 
 ```bash
-sudo apt-get install -y libgtk-4-dev libcairo2-dev
+sudo apt-get install -y \
+  build-essential \
+  libgtk-4-dev \
+  libadwaita-1-dev \
+  libcairo2-dev \
+  gobject-introspection \
+  libgirepository1.0-dev \
+  python3-gi \
+  python3-gi-cairo \
+  valac \
+  xvfb
 ```
 
-From the repository root:
+From the repository root, run the preferred GNOME/libadwaita showcase:
+
+```bash
+cargo run -p ratex-gtk4 --example adw_formula_demo
+```
+
+The Adwaita demo includes:
+
+- a native Adwaita application window and header bar
+- a LaTeX entry field
+- a display-mode toggle
+- a font-size spinner
+- an appearance selector for System / Light / Dark
+- a live `RatexFormula` widget
+
+For a minimal plain-GTK smoke demo, run:
 
 ```bash
 cargo run -p ratex-gtk4 --example formula_demo
 ```
 
-The demo window includes:
+The plain GTK demo includes:
 
 - a LaTeX entry field
 - a display-mode toggle
@@ -41,12 +67,117 @@ Implemented now:
 
 - Cairo renderer for `DisplayList`
 - GTK4 widget subclass with measurement and snapshot drawing
+- C/GObject entry points: `ratex_formula_get_type()` and `ratex_formula_new()`
+- `RatexGtk-1.0.gir` metadata and Vala `.vapi`
+- theme-derived foreground text color when the `color` property is unset
 - bundled-font default behavior
-- local runnable example
+- local runnable Rust GTK, Rust Adwaita, C, Python, and Vala examples
+
+Color behavior:
+
+- If the widget `color` property is unset, default-colored formula items render with GTK's current foreground text color.
+- If the widget `color` property is set, that color is used as the formula default.
+- Inline LaTeX colors such as `\color` and `\textcolor` remain per-item overrides.
 
 Planned next:
 
-- theme-derived default foreground color
-- GObject Introspection (`.gir` / `.typelib`)
-- C, Python, and Vala smoke examples
-- CI coverage for GTK/GI tooling
+- install helper or distro packaging glue for copying headers, shared libraries, `.gir`, `.typelib`, `.vapi`, and `.pc` files into a prefix
+
+## GObject / GI package shape
+
+The public GObject namespace is `RatexGtk-1.0`. The intended install layout is:
+
+```text
+include/ratex-gtk-1.0/ratex-gtk.h
+lib/libratex_gtk4.so
+lib/pkgconfig/ratex-gtk-1.0.pc
+share/gir-1.0/RatexGtk-1.0.gir
+lib/girepository-1.0/RatexGtk-1.0.typelib
+share/vala/vapi/ratex-gtk-1.0.vapi
+```
+
+The checked-in metadata lives under `platforms/gtk/`:
+
+- `include/ratex-gtk-1.0/ratex-gtk.h`
+- `gir/RatexGtk-1.0.gir`
+- `pkgconfig/ratex-gtk-1.0.pc.in`
+- `vapi/ratex-gtk-1.0.vapi`
+- `examples/c/formula_demo.c`
+- `examples/c/init_contract.c`
+- `examples/python/formula_demo.py`
+- `examples/vala/formula_demo.vala`
+
+Initialization contract:
+
+- `RatexFormula` is implemented as a gtk-rs `GtkWidget` subclass.
+- GTK must be initialized on the main thread before querying `RatexFormula`'s type, calling `ratex_formula_new()`, or constructing `RatexGtk.Formula` through GI.
+- Before GTK initialization, `ratex_formula_get_type()` returns `G_TYPE_INVALID` and `ratex_formula_new()` returns `NULL`.
+- C/Python/Vala examples construct the widget from application activation, after GTK has initialized.
+
+Binding metadata maintenance:
+
+- `RatexGtk-1.0.gir` and `ratex-gtk-1.0.vapi` are hand-maintained metadata for the exported Rust GObject type.
+- CI checks the exported C symbols and expected property names to catch basic drift between Rust, C, GIR, and VAPI metadata.
+
+## Local C / GI smoke commands
+
+Build the Rust shared library and the Rust demo:
+
+```bash
+cargo build -p ratex-gtk4 --lib --example formula_demo --example adw_formula_demo
+```
+
+Compile the typelib when `g-ir-compiler` is installed:
+
+```bash
+g-ir-compiler platforms/gtk/gir/RatexGtk-1.0.gir \
+  -o target/debug/RatexGtk-1.0.typelib
+```
+
+Build and run the C example:
+
+```bash
+gcc platforms/gtk/examples/c/formula_demo.c \
+  -o target/debug/ratex-gtk-c-demo \
+  -Iplatforms/gtk/include/ratex-gtk-1.0 \
+  -Ltarget/debug -lratex_gtk4 \
+  $(pkg-config --cflags --libs gtk4) \
+  -Wl,-rpath,$PWD/target/debug
+
+LD_LIBRARY_PATH=$PWD/target/debug target/debug/ratex-gtk-c-demo
+```
+
+Build and run the C initialization-contract smoke test:
+
+```bash
+gcc platforms/gtk/examples/c/init_contract.c \
+  -o target/debug/ratex-gtk-c-init-contract \
+  -Iplatforms/gtk/include/ratex-gtk-1.0 \
+  -Ltarget/debug -lratex_gtk4 \
+  $(pkg-config --cflags --libs gtk4) \
+  -Wl,-rpath,$PWD/target/debug
+
+LD_LIBRARY_PATH=$PWD/target/debug target/debug/ratex-gtk-c-init-contract
+```
+
+Run the Python GI example:
+
+```bash
+LD_LIBRARY_PATH=$PWD/target/debug \
+GI_TYPELIB_PATH=$PWD/target/debug \
+python3 platforms/gtk/examples/python/formula_demo.py
+```
+
+Build and run the Vala example:
+
+```bash
+valac --vapidir=platforms/gtk/vapi \
+  --pkg gtk4 --pkg ratex-gtk-1.0 \
+  -X -Iplatforms/gtk/include/ratex-gtk-1.0 \
+  -X -Ltarget/debug -X -lratex_gtk4 \
+  -X -Wl,-rpath,$PWD/target/debug \
+  platforms/gtk/examples/vala/formula_demo.vala \
+  -o target/debug/ratex-gtk-vala-demo
+
+LD_LIBRARY_PATH=$PWD/target/debug target/debug/ratex-gtk-vala-demo
+```

--- a/platforms/gtk/examples/c/formula_demo.c
+++ b/platforms/gtk/examples/c/formula_demo.c
@@ -1,0 +1,40 @@
+#include <gtk/gtk.h>
+#include <ratex-gtk.h>
+
+static void activate(GtkApplication *app, gpointer user_data) {
+    (void)user_data;
+
+    RatexFormula *ratex_formula = ratex_formula_new();
+    if (ratex_formula == NULL) {
+        g_error("Failed to create RatexFormula");
+    }
+
+    GtkWidget *formula = GTK_WIDGET(ratex_formula);
+    g_object_set(
+        formula,
+        "latex", "\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}",
+        "font-size", 36.0,
+        "display-mode", TRUE,
+        NULL);
+
+    GtkWidget *box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
+    gtk_widget_set_margin_top(box, 24);
+    gtk_widget_set_margin_bottom(box, 24);
+    gtk_widget_set_margin_start(box, 24);
+    gtk_widget_set_margin_end(box, 24);
+    gtk_box_append(GTK_BOX(box), formula);
+
+    GtkWidget *window = gtk_application_window_new(app);
+    gtk_window_set_title(GTK_WINDOW(window), "RaTeX GTK4 C Demo");
+    gtk_window_set_default_size(GTK_WINDOW(window), 900, 240);
+    gtk_window_set_child(GTK_WINDOW(window), box);
+    gtk_window_present(GTK_WINDOW(window));
+}
+
+int main(int argc, char **argv) {
+    GtkApplication *app = gtk_application_new("io.ratex.demo.gtk4.c", G_APPLICATION_DEFAULT_FLAGS);
+    g_signal_connect(app, "activate", G_CALLBACK(activate), NULL);
+    int status = g_application_run(G_APPLICATION(app), argc, argv);
+    g_object_unref(app);
+    return status;
+}

--- a/platforms/gtk/examples/c/init_contract.c
+++ b/platforms/gtk/examples/c/init_contract.c
@@ -1,0 +1,30 @@
+#include <gtk/gtk.h>
+#include <ratex-gtk.h>
+
+int main(void) {
+    if (ratex_formula_get_type() != G_TYPE_INVALID) {
+        g_printerr("ratex_formula_get_type() must be invalid before GTK init\n");
+        return 1;
+    }
+
+    if (ratex_formula_new() != NULL) {
+        g_printerr("ratex_formula_new() must return NULL before GTK init\n");
+        return 1;
+    }
+
+    gtk_init();
+
+    if (ratex_formula_get_type() == G_TYPE_INVALID) {
+        g_printerr("ratex_formula_get_type() must be valid after GTK init\n");
+        return 1;
+    }
+
+    RatexFormula *formula = ratex_formula_new();
+    if (formula == NULL) {
+        g_printerr("ratex_formula_new() must construct after GTK init\n");
+        return 1;
+    }
+
+    g_object_unref(formula);
+    return 0;
+}

--- a/platforms/gtk/examples/python/formula_demo.py
+++ b/platforms/gtk/examples/python/formula_demo.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("RatexGtk", "1.0")
+
+from gi.repository import Gtk, RatexGtk
+
+
+class Demo(Gtk.Application):
+    def __init__(self):
+        super().__init__(application_id="io.ratex.demo.gtk4.python")
+
+    def do_activate(self):
+        formula = RatexGtk.Formula()
+        formula.set_property("latex", r"\int_0^\infty e^{-x^2} dx = \frac{\sqrt{\pi}}{2}")
+        formula.set_property("font-size", 36.0)
+        formula.set_property("display-mode", True)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        box.set_margin_top(24)
+        box.set_margin_bottom(24)
+        box.set_margin_start(24)
+        box.set_margin_end(24)
+        box.append(formula)
+
+        window = Gtk.ApplicationWindow(application=self, title="RaTeX GTK4 Python Demo")
+        window.set_default_size(900, 240)
+        window.set_child(box)
+        window.present()
+
+
+if __name__ == "__main__":
+    raise SystemExit(Demo().run())

--- a/platforms/gtk/examples/vala/formula_demo.vala
+++ b/platforms/gtk/examples/vala/formula_demo.vala
@@ -1,0 +1,34 @@
+using Gtk;
+using RatexGtk;
+
+public class Demo : Gtk.Application {
+    public Demo () {
+        Object (application_id: "io.ratex.demo.gtk4.vala");
+    }
+
+    protected override void activate () {
+        var formula = new RatexGtk.Formula ();
+        formula.latex = "\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}";
+        formula.font_size = 36.0;
+        formula.display_mode = true;
+
+        var box = new Gtk.Box (Gtk.Orientation.VERTICAL, 12);
+        box.margin_top = 24;
+        box.margin_bottom = 24;
+        box.margin_start = 24;
+        box.margin_end = 24;
+        box.append (formula);
+
+        var window = new Gtk.ApplicationWindow (this) {
+            title = "RaTeX GTK4 Vala Demo",
+            default_width = 900,
+            default_height = 240,
+            child = box
+        };
+        window.present ();
+    }
+
+    public static int main (string[] args) {
+        return new Demo ().run (args);
+    }
+}

--- a/platforms/gtk/gir/RatexGtk-1.0.gir
+++ b/platforms/gtk/gir/RatexGtk-1.0.gir
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<repository version="1.2"
+            xmlns="http://www.gtk.org/introspection/core/1.0"
+            xmlns:c="http://www.gtk.org/introspection/c/1.0"
+            xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+  <include name="GObject" version="2.0"/>
+  <include name="Gdk" version="4.0"/>
+  <include name="Gtk" version="4.0"/>
+  <package name="ratex-gtk-1.0"/>
+  <c:include name="ratex-gtk.h"/>
+  <namespace name="RatexGtk"
+             version="1.0"
+             shared-library="libratex_gtk4.so"
+             c:identifier-prefixes="Ratex"
+             c:symbol-prefixes="ratex">
+    <class name="Formula"
+           c:symbol-prefix="formula"
+           c:type="RatexFormula"
+           parent="Gtk.Widget"
+           glib:type-name="RaTeXFormula"
+           glib:get-type="ratex_formula_get_type"
+           glib:type-struct="FormulaClass">
+      <constructor name="new" c:identifier="ratex_formula_new">
+        <return-value transfer-ownership="full" nullable="1">
+          <type name="Formula" c:type="RatexFormula*"/>
+        </return-value>
+      </constructor>
+      <property name="latex" writable="1" readable="1" transfer-ownership="none">
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="display-mode" writable="1" readable="1" transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="font-size" writable="1" readable="1" transfer-ownership="none">
+        <type name="gdouble" c:type="gdouble"/>
+      </property>
+      <property name="padding" writable="1" readable="1" transfer-ownership="none">
+        <type name="gdouble" c:type="gdouble"/>
+      </property>
+      <property name="color" writable="1" readable="1" transfer-ownership="none">
+        <type name="Gdk.RGBA" c:type="GdkRGBA*"/>
+      </property>
+      <property name="font-dir" writable="1" readable="1" transfer-ownership="none">
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="error-message" readable="1" transfer-ownership="none">
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+    </class>
+    <record name="FormulaClass"
+            c:type="RatexFormulaClass"
+            disguised="1"
+            glib:is-gtype-struct-for="Formula"/>
+  </namespace>
+</repository>

--- a/platforms/gtk/include/ratex-gtk-1.0/ratex-gtk.h
+++ b/platforms/gtk/include/ratex-gtk-1.0/ratex-gtk.h
@@ -1,0 +1,23 @@
+/* ratex-gtk.h - GTK4/GObject widget API for RaTeX */
+
+#ifndef RATEX_GTK_H
+#define RATEX_GTK_H
+
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+#define RATEX_TYPE_FORMULA (ratex_formula_get_type())
+
+G_DECLARE_FINAL_TYPE(RatexFormula, ratex_formula, RATEX, FORMULA, GtkWidget)
+
+/* RatexFormula is implemented as a gtk-rs GtkWidget subclass. GTK must be
+ * initialized on the main thread before querying RatexFormula's type or
+ * constructing widgets.
+ * Returns NULL if GTK has not been initialized.
+ */
+RatexFormula *ratex_formula_new(void);
+
+G_END_DECLS
+
+#endif /* RATEX_GTK_H */

--- a/platforms/gtk/pkgconfig/ratex-gtk-1.0.pc.in
+++ b/platforms/gtk/pkgconfig/ratex-gtk-1.0.pc.in
@@ -1,0 +1,14 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=@libdir@
+includedir=@includedir@
+datadir=@datadir@
+girdir=${datadir}/gir-1.0
+typelibdir=${libdir}/girepository-1.0
+
+Name: RatexGtk
+Description: GTK4/GObject widget for native RaTeX math rendering
+Version: @version@
+Requires: gtk4
+Libs: -L${libdir} -lratex_gtk4
+Cflags: -I${includedir}/ratex-gtk-1.0

--- a/platforms/gtk/vapi/ratex-gtk-1.0.vapi
+++ b/platforms/gtk/vapi/ratex-gtk-1.0.vapi
@@ -1,0 +1,23 @@
+[CCode (cprefix = "Ratex", gir_namespace = "RatexGtk", gir_version = "1.0", lower_case_cprefix = "ratex_")]
+namespace RatexGtk {
+    [CCode (cheader_filename = "ratex-gtk.h", cname = "RatexFormula", type_id = "ratex_formula_get_type ()")]
+    public class Formula : Gtk.Widget {
+        [CCode (cname = "ratex_formula_new")]
+        public Formula ();
+
+        [NoAccessorMethod]
+        public string latex { owned get; set; }
+        [NoAccessorMethod]
+        public bool display_mode { get; set; }
+        [NoAccessorMethod]
+        public double font_size { get; set; }
+        [NoAccessorMethod]
+        public double padding { get; set; }
+        [NoAccessorMethod]
+        public Gdk.RGBA? color { owned get; set; }
+        [NoAccessorMethod]
+        public string? font_dir { owned get; set; }
+        [NoAccessorMethod]
+        public string? error_message { owned get; }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds native Linux GTK4 support for RaTeX with a reusable `RatexFormula` widget, a Cairo renderer backend, and GObject Introspection packaging for C, Python, and Vala consumers.

Included in this PR:

- `ratex-cairo` renderer for `DisplayList`
- `ratex-gtk4` `GtkWidget` subclass with measurement and snapshot rendering
- exported C ABI entry points for type lookup and widget construction
- GI metadata and packaging files under `platforms/gtk/`
- runnable examples for Rust GTK, Rust libadwaita, C, Python, and Vala
- CI coverage for shared library build, typelib compilation, metadata drift checks, and Xvfb smoke tests
- theme-aware default color behavior that respects explicit LaTeX colors

## Testing

Validated on the rebased branch with:

- `cargo build --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo test -p ratex-gtk4`
- `cargo test -p ratex-cairo`
- `cargo test -p ratex-pdf --test smoke`
- `cargo build -p ratex-gtk4 --lib --example formula_demo --example adw_formula_demo`
- `g-ir-compiler platforms/gtk/gir/RatexGtk-1.0.gir -o target/debug/RatexGtk-1.0.typelib`
- C example build
- C init-contract smoke build/run
- `python3 -m py_compile platforms/gtk/examples/python/formula_demo.py`
- Vala example build
- `xmllint --noout platforms/gtk/gir/RatexGtk-1.0.gir`
- Xvfb smoke runs for Rust GTK, Rust Adwaita, C init-contract, C demo, Python GI, and Vala demos

## Rendering Approach

This PR intentionally uses the reliable Cairo outline rendering path from `ratex-cairo` rather than attempting native glyph rendering through a FreeType/Cairo `show_glyphs` pipeline.

Why:

- the outline path is faithful to current RaTeX/KaTeX rendering
- the native FreeType/Cairo glyph experiment produced broken output even after exact glyph-id lookup
- shipping the stable outline path is preferable to landing a partially broken glyph backend

Tradeoff:

- this is not the most native glyph rendering approach possible
- a future follow-up could revisit a true native FreeType/Cairo glyph path if it can be made correct

See my earlier comment https://github.com/erweixin/RaTeX/issues/99#issuecomment-4587091724 for more details.

## ABI / Binding Approach

The public widget type is currently exported from the existing gtk-rs `GtkWidget` subclass implementation rather than from a manually registered C-style GTK type.

Why:

- it keeps the implementation smaller, safer, and aligned with the rest of the Rust codebase
- it allows the layout/rendering/widget logic to stay in idiomatic gtk-rs subclass code
- it is the most practical path for landing the first upstream GTK integration

Constraint:

- gtk-rs asserts GTK main-thread initialization during widget subclass registration
- therefore `ratex_formula_get_type()` is not a fully conventional pre-`gtk_init()` GTK type getter
- the current exported contract is:
  - before GTK init: `ratex_formula_get_type()` returns `G_TYPE_INVALID`
  - before GTK init: `ratex_formula_new()` returns `NULL`
  - after GTK init: type lookup and construction succeed

This contract is explicitly documented and covered by a C smoke test in CI.

If we eventually want a fully conventional public GTK/GObject ABI for non-Rust consumers, the likely follow-up would be a lower-level manually registered public type layer, either in C or unsafe Rust FFI.

## Metadata Note

`RatexGtk-1.0.gir` and `ratex-gtk-1.0.vapi` are currently hand-maintained metadata for the exported Rust GObject type. We need to remember to update this in future versions as needed.

This PR adds CI drift checks for:

- exported C symbols
- expected property names across header/GIR/VAPI

That keeps the current approach honest without introducing a full metadata generation pipeline in this first pass. If there is interest, I can add this in the future.