### PR TITLE
fix(ios): resolve Swift/ObjC++ build race and duplicate XCFramework header

### DIFF
--- a/platforms/react-native/ios/RaTeXInlineViewManager.mm
+++ b/platforms/react-native/ios/RaTeXInlineViewManager.mm
@@ -19,7 +19,10 @@
 #import <UIKit/UIKit.h>
 #endif
 
-#import "ratex_react_native-Swift.h"
+// Framework/module import form (not the quote form): forces the Swift module to
+// build before this Objective-C++ TU, avoiding a non-deterministic compile race
+// where -Swift.h is "file not found" on a clean xcodebuild / EAS / CI build.
+#import <ratex_react_native/ratex_react_native-Swift.h>
 #import "RaTeXColorUtils.h"
 
 // ---------------------------------------------------------------------------

--- a/platforms/react-native/ios/RaTeXViewManager.mm
+++ b/platforms/react-native/ios/RaTeXViewManager.mm
@@ -19,8 +19,14 @@
 #import <UIKit/UIKit.h>
 #endif
 
-// Swift-generated header (module name derived from podspec/target name)
-#import "ratex_react_native-Swift.h"
+// Swift-generated header (module name derived from podspec/target name).
+// Use the framework/module form (<module/module-Swift.h>) rather than the quote
+// form: the quote form creates no module dependency, so this Objective-C++ TU can
+// be scheduled to compile BEFORE the Swift target has generated the -Swift.h
+// header — a non-deterministic build race that fails `xcodebuild` (and EAS/CI)
+// with "ratex_react_native-Swift.h file not found". The angle/module form forces
+// the Swift module to build first.
+#import <ratex_react_native/ratex_react_native-Swift.h>
 #import "RaTeXColorUtils.h"
 
 // ---------------------------------------------------------------------------

--- a/platforms/react-native/ratex-react-native.podspec
+++ b/platforms/react-native/ratex-react-native.podspec
@@ -14,6 +14,15 @@ Pod::Spec.new do |s|
 
   # Swift source files + ObjC++ bridge
   s.source_files   = "ios/**/*.{h,m,mm,swift}"
+  # The vendored XCFramework ships a `ratex.h` inside every slice's Headers/ dir
+  # (ios-arm64, ios-arm64_x86_64-simulator, macos-arm64_x86_64). Without this
+  # exclude, the recursive source_files glob picks up all three copies and
+  # CocoaPods emits three CpHeader build commands that resolve to the same output
+  # path → Xcode 15+ fails the build with
+  #   "Multiple commands produce '…/ratex-react-native/ratex.h'".
+  # The framework's headers are exposed through its module (vendored_frameworks),
+  # not through source_files, so excluding them here is safe.
+  s.exclude_files  = "ios/RaTeX.xcframework/**/*"
   s.swift_version  = "5.9"
 
   # Prebuilt static library (libratex_ffi.a) packaged as XCFramework


### PR DESCRIPTION

Two independent issues break a **clean** iOS build of `ratex-react-native` for consumers. Both reproduce on a fresh `xcodebuild` / EAS / CI build but are masked in the Xcode IDE (incremental caching + module reuse hide them), so they're easy to miss in local dev.

## 1. Swift/ObjC++ compile race — `-Swift.h` "file not found"

`ios/RaTeXViewManager.mm` and `ios/RaTeXInlineViewManager.mm` import the Swift-generated header with the **quote form**:

```objc
#import "ratex_react_native-Swift.h"
```

The quote form creates no module dependency, so Clang can schedule these Objective‑C++ translation units to compile **before** the Swift target has emitted `ratex_react_native-Swift.h`. On a clean build this fails non‑deterministically with:

```
'ratex_react_native-Swift.h' file not found
```

**Fix:** use the framework/module form, which forces the Swift module to build first:

```objc
#import <ratex_react_native/ratex_react_native-Swift.h>
```

## 2. Duplicate XCFramework header — "Multiple commands produce …/ratex.h"

The podspec globs all source recursively:

```ruby
s.source_files = "ios/**/*.{h,m,mm,swift}"
```

That glob recurses into `ios/RaTeX.xcframework`, whose three slices each ship a `Headers/ratex.h`:

```
ios/RaTeX.xcframework/ios-arm64/Headers/ratex.h
ios/RaTeX.xcframework/ios-arm64_x86_64-simulator/Headers/ratex.h
ios/RaTeX.xcframework/macos-arm64_x86_64/Headers/ratex.h
```

CocoaPods emits three `CpHeader` commands that resolve to the same output path, so Xcode 15+ fails with:

```
Multiple commands produce '…/ratex-react-native/ratex.h'
```

**Fix:** exclude the vendored framework from `source_files` (its headers are exposed through the framework module via `vendored_frameworks`, not through `source_files`):

```ruby
s.exclude_files = "ios/RaTeX.xcframework/**/*"
```

## Verification

Validated by a downstream consumer (Expo SDK 54, React Native new architecture, static linking) with a clean `expo prebuild --clean` + cold `xcodebuild`:

- **BUILD SUCCEEDED** end-to-end.
- Both `RaTeXViewManager.mm` and `RaTeXInlineViewManager.mm` compile (race gone).
- `RaTeXFonts.bundle` ships in the app.
- No "multiple commands produce" error.

Without this PR, that consumer carries the same two fixes out-of-tree (a `patch-package`/pnpm patch for #1 and a CocoaPods `post_install` hack / Expo config plugin for #2). This PR lets those be dropped.

## Notes for the maintainer

- Both changes are additive and minimal; no behavior change for the rendered output.
- The angle/module import requires the pod to define a module (CocoaPods sets `DEFINES_MODULE` for Swift pods), which is already the case here — confirmed by the consumer's successful build. Happy to adjust if you prefer a different ordering fix (e.g. an explicit module map).
- The `exclude_files` approach is the standard CocoaPods pattern for "vendored framework headers leaking into `source_files`"; an equivalent alternative is to narrow `source_files` to the top level (`ios/*.{h,m,mm,swift}`) since all real sources live directly under `ios/`.
