### PR TITLE
fix(react-native/ios): guard Swift header import with __has_include for static-library builds

### DIFF
--- a/platforms/react-native/ios/RaTeXInlineViewManager.mm
+++ b/platforms/react-native/ios/RaTeXInlineViewManager.mm
@@ -19,10 +19,18 @@
 #import <UIKit/UIKit.h>
 #endif
 
-// Framework/module import form (not the quote form): forces the Swift module to
-// build before this Objective-C++ TU, avoiding a non-deterministic compile race
-// where -Swift.h is "file not found" on a clean xcodebuild / EAS / CI build.
+// Prefer the framework/module form (forces the Swift module to build before this
+// Objective-C++ TU, avoiding a non-deterministic "-Swift.h file not found" compile
+// race on clean xcodebuild/EAS/CI builds). Fall back to the quote form when the
+// module form does not resolve — i.e. when the library builds as a *static library*
+// rather than a framework/clang module (`use_frameworks! :linkage => :static` /
+// Expo `useFrameworks: 'static'`), where the generated header lands only in this
+// target's own DerivedSources. Guard with __has_include so both linkages work.
+#if __has_include(<ratex_react_native/ratex_react_native-Swift.h>)
 #import <ratex_react_native/ratex_react_native-Swift.h>
+#else
+#import "ratex_react_native-Swift.h"
+#endif
 #import "RaTeXColorUtils.h"
 
 // ---------------------------------------------------------------------------

--- a/platforms/react-native/ios/RaTeXViewManager.mm
+++ b/platforms/react-native/ios/RaTeXViewManager.mm
@@ -20,13 +20,22 @@
 #endif
 
 // Swift-generated header (module name derived from podspec/target name).
-// Use the framework/module form (<module/module-Swift.h>) rather than the quote
-// form: the quote form creates no module dependency, so this Objective-C++ TU can
-// be scheduled to compile BEFORE the Swift target has generated the -Swift.h
-// header — a non-deterministic build race that fails `xcodebuild` (and EAS/CI)
-// with "ratex_react_native-Swift.h file not found". The angle/module form forces
-// the Swift module to build first.
+// Prefer the framework/module form (<module/module-Swift.h>) when it resolves: it
+// creates a module dependency that forces the Swift target to build BEFORE this
+// Objective-C++ TU, avoiding a non-deterministic build race that fails `xcodebuild`
+// (and EAS/CI) with "ratex_react_native-Swift.h file not found". But when the
+// library is built as a *static library* rather than a framework/clang module —
+// e.g. `use_frameworks! :linkage => :static` (Expo's `useFrameworks: 'static'`,
+// required to statically link some RN pods such as RNFirebase) — the generated
+// header is emitted only into this target's own DerivedSources and the
+// angle/module form no longer resolves. Guard with __has_include so framework
+// builds keep the race-avoidance and static-library builds fall back to the quote
+// form (which resolves against DerivedSources). Linkage-agnostic.
+#if __has_include(<ratex_react_native/ratex_react_native-Swift.h>)
 #import <ratex_react_native/ratex_react_native-Swift.h>
+#else
+#import "ratex_react_native-Swift.h"
+#endif
 #import "RaTeXColorUtils.h"
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`RaTeXViewManager.mm` and `RaTeXInlineViewManager.mm` import the Swift-generated header via the framework/module form:

```objc
#import <ratex_react_native/ratex_react_native-Swift.h>
```

As the inline comments note, this is intentional — the module form forces the Swift target to build before the Objective-C++ TU, avoiding a non-deterministic `ratex_react_native-Swift.h file not found` race on clean `xcodebuild` / EAS / CI builds.

However, when an app builds ratex as a **static library** instead of a framework/clang module — e.g. `use_frameworks! :linkage => :static`, which Expo exposes as `useFrameworks: 'static'` and which is required to statically link certain RN pods (RNFirebase, etc.) — the Swift-generated header is emitted only into the target's own `DerivedSources`. The angle/module form no longer resolves there and the build fails:

```
'ratex_react_native/ratex_react_native-Swift.h' file not found
```

The quote form (`#import "ratex_react_native-Swift.h"`) resolves against `DerivedSources` and works under static linking, but switching to it unconditionally would reintroduce the compile race for framework/module builds.

## Fix

Guard the import with `__has_include`, keeping the module form when it is available (frameworks/modules — preserves the race-avoidance) and falling back to the quote form otherwise (static libraries):

```objc
#if __has_include(<ratex_react_native/ratex_react_native-Swift.h>)
#import <ratex_react_native/ratex_react_native-Swift.h>
#else
#import "ratex_react_native-Swift.h"
#endif
```

This is the idiomatic pattern for Swift-generated headers in RN native modules that may be consumed as either a framework or a static library, and is linkage-agnostic.

## Testing

- **Static linking (the failing case):** the `#else` (quote) branch is what we currently ship downstream on Expo SDK 57 / RN 0.86 with `useFrameworks: 'static'` (carried as a local `pnpm` patch of `0.1.12`) — it resolves and builds cleanly. This PR upstreams it behind the guard so the module-form path is unchanged.
- **Framework/module builds:** take the `#if` (module) branch — identical to current `main`, no behavior change.

Downstream we carry this as a local patch; upstreaming it lets us drop the patch. Happy to adjust the wording or split per file if you prefer.