### PR TITLE
fix: RaTeXView has no size in `useLayoutEffect` on first render (New Arch)

### DIFF
--- a/demo/react-native-expo/App.tsx
+++ b/demo/react-native-expo/App.tsx
@@ -65,19 +65,21 @@ function MeasuredFormula({ latex }: { latex: string }) {
   const [firstPass, setFirstPass] = useState<{ w: number; h: number } | null>(
     null
   );
-  const firstCaptured = useRef(false);
-
-  useLayoutEffect(() => {
+  const measure = useCallback(() => {
     const node = hostRef.current;
     if (!node) return;
     node.measure((_x, _y, w, h) => {
-      setDeco({ w, h });
-      if (!firstCaptured.current) {
-        firstCaptured.current = true;
-        setFirstPass({ w, h });
-      }
+      // Capture only the FIRST commit's measurement (the #120 signal).
+      setFirstPass((prev) => prev ?? { w, h });
+      // Guard object identity so an unchanged size doesn't re-trigger a render.
+      setDeco((prev) => (prev && prev.w === w && prev.h === h ? prev : { w, h }));
     });
-  });
+  }, []);
+
+  // Runs once after the first commit; the component is keyed so remounts re-test.
+  useLayoutEffect(() => {
+    measure();
+  }, [measure]);
 
   const ok = firstPass ? firstPass.w > 0 && firstPass.h > 0 : null;
 
@@ -87,7 +89,12 @@ function MeasuredFormula({ latex }: { latex: string }) {
         {/* collapsable={false} keeps the wrapper in the native tree on Android
             so measure() targets it instead of being flattened away. */}
         <View ref={hostRef} collapsable={false} style={styles.measureHost}>
-          <RaTeXView latex={latex} fontSize={30} displayMode={true} />
+          <RaTeXView
+            latex={latex}
+            fontSize={30}
+            displayMode={true}
+            onContentSizeChange={measure}
+          />
           {deco && deco.w > 0 && deco.h > 0 ? (
             <>
               <View

--- a/demo/react-native-expo/App.tsx
+++ b/demo/react-native-expo/App.tsx
@@ -14,7 +14,7 @@
  */
 
 import { StatusBar } from "expo-status-bar";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useLayoutEffect, useRef } from "react";
 import {
   StyleSheet,
   Text,
@@ -46,6 +46,106 @@ const PAGES = [
   },
   { id: "7", latex: String.raw`\text{😊} \quad E=mc^2` },
 ];
+
+// ─── Case #120: useLayoutEffect measurement drives an absolute decoration ─────
+// https://github.com/erweixin/RaTeX/issues/120
+//
+// The dashed frame and blue baseline are positioned absolutely from geometry
+// computed *inside useLayoutEffect* via ref.measure(). React flushes layout
+// effects (and the state they set) before paint, so:
+//   - Fixed:   the view reports its real size on the first commit → the frame
+//              hugs the formula the instant it appears (no flash).
+//   - Broken:  the view reports 0×0 on the first commit → the frame starts
+//              collapsed and only jumps into place a few frames later.
+// The caption records what the FIRST useLayoutEffect pass measured, so the
+// per-platform behavior is visible even if the jump is quick.
+function MeasuredFormula({ latex }: { latex: string }) {
+  const hostRef = useRef<View>(null);
+  const [deco, setDeco] = useState<{ w: number; h: number } | null>(null);
+  const [firstPass, setFirstPass] = useState<{ w: number; h: number } | null>(
+    null
+  );
+  const firstCaptured = useRef(false);
+
+  useLayoutEffect(() => {
+    const node = hostRef.current;
+    if (!node) return;
+    node.measure((_x, _y, w, h) => {
+      setDeco({ w, h });
+      if (!firstCaptured.current) {
+        firstCaptured.current = true;
+        setFirstPass({ w, h });
+      }
+    });
+  });
+
+  const ok = firstPass ? firstPass.w > 0 && firstPass.h > 0 : null;
+
+  return (
+    <View style={styles.measureBody}>
+      <View style={styles.measureStage}>
+        {/* collapsable={false} keeps the wrapper in the native tree on Android
+            so measure() targets it instead of being flattened away. */}
+        <View ref={hostRef} collapsable={false} style={styles.measureHost}>
+          <RaTeXView latex={latex} fontSize={30} displayMode={true} />
+          {deco && deco.w > 0 && deco.h > 0 ? (
+            <>
+              <View
+                pointerEvents="none"
+                style={[styles.decoFrame, { width: deco.w, height: deco.h }]}
+              />
+              <View
+                pointerEvents="none"
+                style={[styles.decoBaseline, { width: deco.w, top: deco.h }]}
+              />
+            </>
+          ) : null}
+        </View>
+      </View>
+      <Text style={styles.measureMeta}>
+        {"useLayoutEffect measure(): "}
+        {firstPass
+          ? `${firstPass.w.toFixed(0)}×${firstPass.h.toFixed(0)}`
+          : "—"}
+        {ok === null
+          ? ""
+          : ok
+          ? "  ✓ real size on first commit"
+          : "  ✗ 0×0 on first commit (flash)"}
+      </Text>
+    </View>
+  );
+}
+
+function CaseLayoutEffectMeasure() {
+  const [remount, setRemount] = useState(0);
+  const [idx, setIdx] = useState(0);
+  const latex = idx === 0 ? EXPR : idx === 1 ? EXPR2 : EXPR3;
+
+  return (
+    <View style={[styles.card, styles.measureCard]}>
+      <View style={styles.cardHeader}>
+        <Text style={styles.cardTitle}>
+          #120: useLayoutEffect measure → absolute decoration
+        </Text>
+      </View>
+      <Text style={styles.measureHint}>
+        The dashed frame + blue baseline are sized from ref.measure() inside
+        useLayoutEffect. Fixed → they hug the formula immediately. Broken → they
+        start at 0 and jump. Press Remount to re-test the first commit.
+      </Text>
+      <MeasuredFormula key={`${remount}-${idx}`} latex={latex} />
+      <View style={styles.smokeRow}>
+        <Pressable style={styles.smokeBtn} onPress={() => setRemount((r) => r + 1)}>
+          <Text style={styles.smokeBtnText}>Remount</Text>
+        </Pressable>
+        <Pressable style={styles.smokeBtn} onPress={() => setIdx((i) => (i + 1) % 3)}>
+          <Text style={styles.smokeBtnText}>Next formula</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
 
 // ─── Status indicator ────────────────────────────────────────────────
 function StatusDot({ status }: { status: "pending" | "ok" | "error" }) {
@@ -293,7 +393,7 @@ export default function App() {
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
       >
-        <Text style={styles.title}>RaTeX Repro — Issue #42</Text>
+        <Text style={styles.title}>RaTeX Repro — Issues #120 / #42</Text>
         <Text style={styles.subtitle}>
           Render #{key} — gray dot = pending, green = rendered, red = error
         </Text>
@@ -302,6 +402,7 @@ export default function App() {
           <Text style={styles.buttonText}>Force Re-mount (key={key + 1})</Text>
         </Pressable>
 
+        <CaseLayoutEffectMeasure />
         <CasePR45Smoke />
         <CaseInlineTeXCustomFont />
 
@@ -353,6 +454,53 @@ const styles = StyleSheet.create({
     minHeight: 520,
     padding: 12,
     gap: 12,
+  },
+  measureCard: {
+    flex: 0,
+    marginHorizontal: 12,
+    marginTop: 8,
+    marginBottom: 8,
+    paddingBottom: 12,
+  },
+  measureHint: {
+    fontSize: 10,
+    color: "#6b7280",
+    paddingHorizontal: 12,
+    marginTop: 8,
+    marginBottom: 4,
+  },
+  measureBody: {
+    paddingHorizontal: 12,
+  },
+  measureStage: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 24,
+  },
+  measureHost: {
+    position: "relative",
+  },
+  decoFrame: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+    borderWidth: 2,
+    borderColor: "#e11d48",
+    borderStyle: "dashed",
+    borderRadius: 2,
+  },
+  decoBaseline: {
+    position: "absolute",
+    left: 0,
+    height: 2,
+    backgroundColor: "#2563eb",
+  },
+  measureMeta: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: "#111827",
+    textAlign: "center",
+    marginTop: 4,
   },
   smokeCard: {
     flex: 0,

--- a/platforms/react-native/android/src/main/jni/CMakeLists.txt
+++ b/platforms/react-native/android/src/main/jni/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+set(LIB_LITERAL RNRaTeXSpec)
+set(LIB_TARGET_NAME react_codegen_${LIB_LITERAL})
+
+set(LIB_ANDROID_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+set(LIB_ANDROID_GENERATED_JNI_DIR ${LIB_ANDROID_DIR}/build/generated/source/codegen/jni)
+set(LIB_ANDROID_GENERATED_COMPONENTS_DIR ${LIB_ANDROID_GENERATED_JNI_DIR}/react/renderer/components/${LIB_LITERAL})
+
+file(GLOB LIB_MODULE_SRCS CONFIGURE_DEPENDS *.cpp react/renderer/components/${LIB_LITERAL}/*.cpp)
+file(GLOB LIB_CODEGEN_SRCS CONFIGURE_DEPENDS ${LIB_ANDROID_GENERATED_COMPONENTS_DIR}/*.cpp ${LIB_ANDROID_GENERATED_JNI_DIR}/*.cpp)
+
+add_library(
+        ${LIB_TARGET_NAME}
+        SHARED
+        ${LIB_MODULE_SRCS}
+        ${LIB_CODEGEN_SRCS}
+)
+
+target_include_directories(
+        ${LIB_TARGET_NAME}
+        PUBLIC
+        .
+        ./react/renderer/components/${LIB_LITERAL}
+        ${LIB_ANDROID_GENERATED_JNI_DIR}
+        ${LIB_ANDROID_GENERATED_COMPONENTS_DIR}
+)
+
+target_link_libraries(
+        ${LIB_TARGET_NAME}
+        fbjni
+        jsi
+        reactnative
+)
+
+target_compile_reactnative_options(${LIB_TARGET_NAME} PRIVATE)

--- a/platforms/react-native/android/src/main/jni/CMakeLists.txt
+++ b/platforms/react-native/android/src/main/jni/CMakeLists.txt
@@ -27,11 +27,47 @@ target_include_directories(
         ${LIB_ANDROID_GENERATED_COMPONENTS_DIR}
 )
 
-target_link_libraries(
-        ${LIB_TARGET_NAME}
-        fbjni
-        jsi
-        reactnative
-)
+# https://github.com/react-native-community/discussions-and-proposals/discussions/816
+# This if-then-else can be removed once this library does not support versions below 0.76
+if(REACTNATIVE_MERGED_SO)
+  target_link_libraries(
+          ${LIB_TARGET_NAME}
+          fbjni
+          jsi
+          reactnative
+  )
+else()
+  target_link_libraries(
+          ${LIB_TARGET_NAME}
+          fbjni
+          folly_runtime
+          glog
+          jsi
+          react_codegen_rncore
+          react_debug
+          react_nativemodule_core
+          react_render_core
+          react_render_debug
+          react_render_graphics
+          react_render_mapbuffer
+          react_render_componentregistry
+          react_utils
+          rrc_view
+          turbomodulejsijni
+          yoga
+  )
+endif()
 
-target_compile_reactnative_options(${LIB_TARGET_NAME} PRIVATE)
+# target_compile_reactnative_options only exists in React Native >= 0.80
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
+  target_compile_reactnative_options(${LIB_TARGET_NAME} PRIVATE)
+else()
+  target_compile_options(
+          ${LIB_TARGET_NAME}
+          PRIVATE
+          -fexceptions
+          -frtti
+          -std=c++20
+          -Wall
+  )
+endif()

--- a/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/ComponentDescriptors.h
+++ b/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/ComponentDescriptors.h
@@ -1,0 +1,25 @@
+/**
+ * Hand-written override of the codegen ComponentDescriptors.h. It is placed
+ * ahead of the generated one on the include path so that autolinking (which
+ * registers `RaTeXViewComponentDescriptor`) and the codegen registration both
+ * pick up the measurable descriptor for <RaTeXView>. <RaTeXInlineView> keeps the
+ * default descriptor.
+ */
+#pragma once
+
+#include <react/renderer/components/RNRaTeXSpec/ShadowNodes.h>
+#include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+
+#include "RaTeXViewMeasuringComponentDescriptor.h"
+
+namespace facebook::react {
+
+using RaTeXInlineViewComponentDescriptor =
+    ConcreteComponentDescriptor<RaTeXInlineViewShadowNode>;
+using RaTeXViewComponentDescriptor = RaTeXViewMeasuringComponentDescriptor;
+
+void RNRaTeXSpec_registerComponentDescriptorsFromCodegen(
+    std::shared_ptr<const ComponentDescriptorProviderRegistry> registry);
+
+} // namespace facebook::react

--- a/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/RaTeXViewMeasurementManager.cpp
+++ b/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/RaTeXViewMeasurementManager.cpp
@@ -1,0 +1,59 @@
+#include "RaTeXViewMeasurementManager.h"
+
+#include "conversions.h"
+
+#include <fbjni/fbjni.h>
+#include <react/jni/ReadableNativeMap.h>
+#include <react/renderer/core/conversions.h>
+
+using namespace facebook::jni;
+
+namespace facebook::react {
+
+Size RaTeXViewMeasurementManager::measure(
+    SurfaceId surfaceId,
+    LayoutConstraints layoutConstraints,
+    const RaTeXViewProps& props) const {
+  const jni::global_ref<jobject>& fabricUIManager =
+      contextContainer_->at<jni::global_ref<jobject>>("FabricUIManager");
+
+  static const auto measure =
+      facebook::jni::findClassStatic("com/facebook/react/fabric/FabricUIManager")
+          ->getMethod<jlong(
+              jint,
+              jstring,
+              ReadableMap::javaobject,
+              ReadableMap::javaobject,
+              ReadableMap::javaobject,
+              jfloat,
+              jfloat,
+              jfloat,
+              jfloat)>("measure");
+
+  auto minimumSize = layoutConstraints.minimumSize;
+  auto maximumSize = layoutConstraints.maximumSize;
+
+  local_ref<JString> componentName = make_jstring("RaTeXView");
+
+  auto serializedProps = toDynamic(props);
+  local_ref<ReadableNativeMap::javaobject> propsRNM =
+      ReadableNativeMap::newObjectCxxArgs(serializedProps);
+  local_ref<ReadableMap::javaobject> propsRM =
+      make_local(reinterpret_cast<ReadableMap::javaobject>(propsRNM.get()));
+
+  auto measurement = yogaMeassureToSize(measure(
+      fabricUIManager,
+      surfaceId,
+      componentName.get(),
+      nullptr,
+      propsRM.get(),
+      nullptr,
+      minimumSize.width,
+      maximumSize.width,
+      minimumSize.height,
+      maximumSize.height));
+
+  return measurement;
+}
+
+} // namespace facebook::react

--- a/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/RaTeXViewMeasurementManager.h
+++ b/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/RaTeXViewMeasurementManager.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <react/renderer/components/RNRaTeXSpec/Props.h>
+#include <react/renderer/core/LayoutConstraints.h>
+#include <react/utils/ContextContainer.h>
+
+namespace facebook::react {
+
+// Bridges the shadow node's synchronous measureContent to the platform, by
+// invoking FabricUIManager.measure (which routes to RaTeXViewManager.measure in
+// Kotlin) over JNI. The FabricUIManager instance is retrieved from the
+// contextContainer supplied to the component descriptor.
+class RaTeXViewMeasurementManager {
+ public:
+  RaTeXViewMeasurementManager(
+      const std::shared_ptr<const ContextContainer>& contextContainer)
+      : contextContainer_(contextContainer) {}
+
+  Size measure(
+      SurfaceId surfaceId,
+      LayoutConstraints layoutConstraints,
+      const RaTeXViewProps& props) const;
+
+ private:
+  const std::shared_ptr<const ContextContainer> contextContainer_;
+};
+
+} // namespace facebook::react

--- a/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/RaTeXViewMeasuringComponentDescriptor.h
+++ b/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/RaTeXViewMeasuringComponentDescriptor.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "RaTeXViewMeasurementManager.h"
+#include "RaTeXViewMeasuringShadowNode.h"
+
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+
+namespace facebook::react {
+
+// Component descriptor for the measurable <RaTeXView> shadow node. Creates one
+// measurement manager (holding the contextContainer) and injects it into every
+// shadow node via adopt().
+class RaTeXViewMeasuringComponentDescriptor final
+    : public ConcreteComponentDescriptor<RaTeXViewMeasuringShadowNode> {
+ public:
+  RaTeXViewMeasuringComponentDescriptor(
+      const ComponentDescriptorParameters& parameters)
+      : ConcreteComponentDescriptor(parameters),
+        measurementsManager_(
+            std::make_shared<RaTeXViewMeasurementManager>(contextContainer_)) {}
+
+  void adopt(ShadowNode& shadowNode) const override {
+    ConcreteComponentDescriptor::adopt(shadowNode);
+    auto& node = static_cast<RaTeXViewMeasuringShadowNode&>(shadowNode);
+    node.setMeasurementManager(measurementsManager_);
+  }
+
+ private:
+  const std::shared_ptr<RaTeXViewMeasurementManager> measurementsManager_;
+};
+
+} // namespace facebook::react

--- a/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/RaTeXViewMeasuringShadowNode.cpp
+++ b/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/RaTeXViewMeasuringShadowNode.cpp
@@ -1,0 +1,20 @@
+#include "RaTeXViewMeasuringShadowNode.h"
+
+#include <react/renderer/core/LayoutContext.h>
+
+namespace facebook::react {
+
+void RaTeXViewMeasuringShadowNode::setMeasurementManager(
+    const std::shared_ptr<RaTeXViewMeasurementManager>& measurementsManager) {
+  ensureUnsealed();
+  measurementsManager_ = measurementsManager;
+}
+
+Size RaTeXViewMeasuringShadowNode::measureContent(
+    const LayoutContext& layoutContext,
+    const LayoutConstraints& layoutConstraints) const {
+  return measurementsManager_->measure(
+      getSurfaceId(), layoutConstraints, getConcreteProps());
+}
+
+} // namespace facebook::react

--- a/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/RaTeXViewMeasuringShadowNode.cpp
+++ b/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/RaTeXViewMeasuringShadowNode.cpp
@@ -13,8 +13,12 @@ void RaTeXViewMeasuringShadowNode::setMeasurementManager(
 Size RaTeXViewMeasuringShadowNode::measureContent(
     const LayoutContext& layoutContext,
     const LayoutConstraints& layoutConstraints) const {
-  return measurementsManager_->measure(
-      getSurfaceId(), layoutConstraints, getConcreteProps());
+  const auto& props = getConcreteProps();
+  if (props.latex.empty() || props.fontSize <= 0) {
+    return layoutConstraints.clamp({0, 0});
+  }
+  return layoutConstraints.clamp(
+      measurementsManager_->measure(getSurfaceId(), layoutConstraints, props));
 }
 
 } // namespace facebook::react

--- a/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/RaTeXViewMeasuringShadowNode.h
+++ b/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/RaTeXViewMeasuringShadowNode.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "RaTeXViewMeasurementManager.h"
+
+#include <react/renderer/components/RNRaTeXSpec/ShadowNodes.h>
+
+namespace facebook::react {
+
+// Measurable shadow node for <RaTeXView>. Subclasses the codegen shadow node and
+// adds the Yoga measure traits + a synchronous measureContent, so the view has
+// its real size on the first commit (e.g. at JS useLayoutEffect) instead of only
+// after the async onContentSizeChange event. Mirrors the iOS measuring node.
+class RaTeXViewMeasuringShadowNode final : public RaTeXViewShadowNode {
+ public:
+  using RaTeXViewShadowNode::RaTeXViewShadowNode;
+
+  static ShadowNodeTraits BaseTraits() {
+    auto traits = RaTeXViewShadowNode::BaseTraits();
+    traits.set(ShadowNodeTraits::Trait::LeafYogaNode);
+    traits.set(ShadowNodeTraits::Trait::MeasurableYogaNode);
+    return traits;
+  }
+
+  void setMeasurementManager(
+      const std::shared_ptr<RaTeXViewMeasurementManager>& measurementsManager);
+
+  Size measureContent(
+      const LayoutContext& layoutContext,
+      const LayoutConstraints& layoutConstraints) const override;
+
+ private:
+  std::shared_ptr<RaTeXViewMeasurementManager> measurementsManager_;
+};
+
+} // namespace facebook::react

--- a/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/conversions.h
+++ b/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/conversions.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <folly/dynamic.h>
+#include <react/renderer/components/RNRaTeXSpec/Props.h>
+
+namespace facebook::react {
+
+#ifdef RN_SERIALIZABLE_STATE
+// Serialize the props the Kotlin measure() needs. Color does not affect the
+// measured size, so it is intentionally omitted.
+inline folly::dynamic toDynamic(const RaTeXViewProps& props) {
+  folly::dynamic serializedProps = folly::dynamic::object();
+  serializedProps["latex"] = props.latex;
+  serializedProps["fontSize"] = props.fontSize;
+  serializedProps["displayMode"] = props.displayMode;
+  return serializedProps;
+}
+#endif
+
+} // namespace facebook::react

--- a/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/conversions.h
+++ b/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/conversions.h
@@ -5,7 +5,6 @@
 
 namespace facebook::react {
 
-#ifdef RN_SERIALIZABLE_STATE
 // Serialize the props the Kotlin measure() needs. Color does not affect the
 // measured size, so it is intentionally omitted.
 inline folly::dynamic toDynamic(const RaTeXViewProps& props) {
@@ -15,6 +14,5 @@ inline folly::dynamic toDynamic(const RaTeXViewProps& props) {
   serializedProps["displayMode"] = props.displayMode;
   return serializedProps;
 }
-#endif
 
 } // namespace facebook::react

--- a/platforms/react-native/android/src/newarch/kotlin/io/ratex/RaTeXViewManager.kt
+++ b/platforms/react-native/android/src/newarch/kotlin/io/ratex/RaTeXViewManager.kt
@@ -2,8 +2,10 @@
 
 package io.ratex
 
+import android.content.Context
 import android.graphics.Color
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
@@ -11,6 +13,8 @@ import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RaTeXViewManagerDelegate
 import com.facebook.react.viewmanagers.RaTeXViewManagerInterface
+import com.facebook.yoga.YogaMeasureMode
+import com.facebook.yoga.YogaMeasureOutput
 
 @ReactModule(name = RaTeXViewManager.NAME)
 class RaTeXViewManager(private val reactContext: ReactApplicationContext) :
@@ -64,5 +68,39 @@ class RaTeXViewManager(private val reactContext: ReactApplicationContext) :
     @ReactProp(name = "color", customType = "Color")
     override fun setColor(view: RaTeXView, value: Int?) {
         view.color = value ?: Color.BLACK
+    }
+
+    // Synchronous intrinsic measure for Fabric, invoked by the custom C++ shadow
+    // node's measureContent via FabricUIManager.measure. Gives the view its real
+    // size on the first commit (e.g. at JS useLayoutEffect) instead of only after
+    // the async onContentSizeChange event. Parsing is thread-safe and fonts are not
+    // needed for measurement; color does not affect size, so it is ignored here.
+    override fun measure(
+        context: Context,
+        localData: ReadableMap?,
+        props: ReadableMap?,
+        state: ReadableMap?,
+        width: Float,
+        widthMode: YogaMeasureMode?,
+        height: Float,
+        heightMode: YogaMeasureMode?,
+        attachmentsPositions: FloatArray?,
+    ): Long {
+        val latex = props?.getString("latex").orEmpty()
+        val fontSize =
+            if (props?.hasKey("fontSize") == true) props.getDouble("fontSize").toFloat() else 24f
+        if (latex.isBlank() || fontSize <= 0f) {
+            return YogaMeasureOutput.make(0f, 0f)
+        }
+        val displayMode =
+            if (props?.hasKey("displayMode") == true) props.getBoolean("displayMode") else true
+        return try {
+            val density = context.resources.displayMetrics.density
+            val displayList = RaTeXEngine.parseBlocking(latex, displayMode, Color.BLACK)
+            val renderer = RaTeXRenderer(displayList, fontSize * density)
+            YogaMeasureOutput.make(renderer.widthPx / density, renderer.totalHeightPx / density)
+        } catch (e: Throwable) {
+            YogaMeasureOutput.make(0f, 0f)
+        }
     }
 }

--- a/platforms/react-native/ios/RaTeXInlineViewManager.mm
+++ b/platforms/react-native/ios/RaTeXInlineViewManager.mm
@@ -22,7 +22,13 @@
 // Framework/module import form (not the quote form): forces the Swift module to
 // build before this Objective-C++ TU, avoiding a non-deterministic compile race
 // where -Swift.h is "file not found" on a clean xcodebuild / EAS / CI build.
+// Fall back to the quote form under Expo prebuild, where the module-qualified
+// header is not on the search path and the module form is "file not found".
+#if __has_include(<ratex_react_native/ratex_react_native-Swift.h>)
 #import <ratex_react_native/ratex_react_native-Swift.h>
+#else
+#import "ratex_react_native-Swift.h"
+#endif
 #import "RaTeXColorUtils.h"
 
 // ---------------------------------------------------------------------------

--- a/platforms/react-native/ios/RaTeXRNView.swift
+++ b/platforms/react-native/ios/RaTeXRNView.swift
@@ -199,3 +199,24 @@ public class RaTeXRNView: PlatformView {
         }
     }
 }
+
+/// Thread-safe synchronous LaTeX measurement.
+///
+/// Used by the Fabric shadow node's `measureContent` so the component self-sizes
+/// during Yoga layout — making its size available at `useLayoutEffect` instead of
+/// only after the async `onContentSizeChange` event. Safe to call off the main
+/// thread: `RaTeXEngine.parse` is thread-safe (thread-local FFI error state) and
+/// `RaTeXRenderer` is a value type; fonts are not needed for measurement.
+@objc(RaTeXMeasure)
+public final class RaTeXMeasure: NSObject {
+    @objc public static func measureLatex(_ latex: String, fontSize: CGFloat, displayMode: Bool) -> CGSize {
+        guard !latex.isEmpty, fontSize > 0 else { return .zero }
+        do {
+            let displayList = try RaTeXEngine.shared.parse(latex, displayMode: displayMode, color: .black)
+            let renderer = RaTeXRenderer(displayList: displayList, fontSize: fontSize)
+            return CGSize(width: renderer.width, height: renderer.totalHeight)
+        } catch {
+            return .zero
+        }
+    }
+}

--- a/platforms/react-native/ios/RaTeXViewManager.mm
+++ b/platforms/react-native/ios/RaTeXViewManager.mm
@@ -26,7 +26,13 @@
 // header — a non-deterministic build race that fails `xcodebuild` (and EAS/CI)
 // with "ratex_react_native-Swift.h file not found". The angle/module form forces
 // the Swift module to build first.
+// Fall back to the quote form under Expo prebuild, where the module-qualified
+// header is not on the search path and the module form is "file not found".
+#if __has_include(<ratex_react_native/ratex_react_native-Swift.h>)
 #import <ratex_react_native/ratex_react_native-Swift.h>
+#else
+#import "ratex_react_native-Swift.h"
+#endif
 #import "RaTeXColorUtils.h"
 
 // ---------------------------------------------------------------------------

--- a/platforms/react-native/ios/RaTeXViewManager.mm
+++ b/platforms/react-native/ios/RaTeXViewManager.mm
@@ -70,6 +70,9 @@ class RaTeXViewMeasuringShadowNode final : public RaTeXViewShadowNode {
       return layoutConstraints.clamp(facebook::react::Size{0, 0});
     }
     NSString *latex = [NSString stringWithUTF8String:props.latex.c_str()];
+    if (latex == nil) {
+      return layoutConstraints.clamp(facebook::react::Size{0, 0});
+    }
     CGSize measured = [RaTeXMeasure measureLatex:latex
                                         fontSize:static_cast<CGFloat>(props.fontSize)
                                      displayMode:props.displayMode ? YES : NO];

--- a/platforms/react-native/ios/RaTeXViewManager.mm
+++ b/platforms/react-native/ios/RaTeXViewManager.mm
@@ -8,6 +8,8 @@
 #import <react/renderer/components/RNRaTeXSpec/EventEmitters.h>
 #import <react/renderer/components/RNRaTeXSpec/Props.h>
 #import <react/renderer/components/RNRaTeXSpec/RCTComponentViewHelpers.h>
+#import <react/renderer/core/LayoutConstraints.h>
+#import <react/renderer/core/LayoutContext.h>
 #else
 #import "RaTeXViewManager.h"
 #import <React/RCTUIManager.h>
@@ -43,6 +45,44 @@
 
 using namespace facebook::react;
 
+namespace {
+
+// A ShadowNode that measures the formula synchronously during Yoga layout, using
+// the (thread-safe) RaTeX engine. This makes the view's size available on the very
+// first commit — i.e. at JS `useLayoutEffect` — instead of only after the async
+// `onContentSizeChange` event, which otherwise causes a one-frame 0-size flash and
+// breaks synchronous reserve-then-place layout (e.g. TextKit attachments).
+class RaTeXViewMeasuringShadowNode final : public RaTeXViewShadowNode {
+ public:
+  using RaTeXViewShadowNode::RaTeXViewShadowNode;
+
+  static ShadowNodeTraits BaseTraits() {
+    auto traits = RaTeXViewShadowNode::BaseTraits();
+    traits.set(ShadowNodeTraits::Trait::LeafYogaNode);
+    traits.set(ShadowNodeTraits::Trait::MeasurableYogaNode);
+    return traits;
+  }
+
+  facebook::react::Size measureContent(const LayoutContext &layoutContext,
+                                       const LayoutConstraints &layoutConstraints) const override {
+    const auto &props = getConcreteProps();
+    if (props.latex.empty() || props.fontSize <= 0) {
+      return layoutConstraints.clamp(facebook::react::Size{0, 0});
+    }
+    NSString *latex = [NSString stringWithUTF8String:props.latex.c_str()];
+    CGSize measured = [RaTeXMeasure measureLatex:latex
+                                        fontSize:static_cast<CGFloat>(props.fontSize)
+                                     displayMode:props.displayMode ? YES : NO];
+    facebook::react::Size size{static_cast<Float>(measured.width), static_cast<Float>(measured.height)};
+    return layoutConstraints.clamp(size);
+  }
+};
+
+using RaTeXViewMeasuringComponentDescriptor =
+    ConcreteComponentDescriptor<RaTeXViewMeasuringShadowNode>;
+
+}  // namespace
+
 // Class name follows RN Fabric convention: {ComponentName}ComponentView
 // so that RCTThirdPartyComponentsProvider can resolve it via NSClassFromString.
 @interface RaTeXViewComponentView : RCTViewComponentView
@@ -54,7 +94,7 @@ using namespace facebook::react;
 
 + (ComponentDescriptorProvider)componentDescriptorProvider
 {
-  return concreteComponentDescriptorProvider<RaTeXViewComponentDescriptor>();
+  return concreteComponentDescriptorProvider<RaTeXViewMeasuringComponentDescriptor>();
 }
 
 - (instancetype)initWithFrame:(CGRect)frame

--- a/platforms/react-native/react-native.config.js
+++ b/platforms/react-native/react-native.config.js
@@ -7,6 +7,7 @@ module.exports = {
         sourceDir: './android',
         packageImportPath: 'import io.ratex.RaTeXPackage;',
         packageInstance: 'new RaTeXPackage()',
+        cmakeListsPath: './src/main/jni/CMakeLists.txt',
       },
     },
   },


### PR DESCRIPTION
# Fix: RaTeXView has no size in `useLayoutEffect` on first render (New Arch)

Fixes #120.

On the New Architecture, `RaTeXView` reported `0×0` when measured in `useLayoutEffect` right after mount — the real size only arrived a few frames later via the async `onContentSizeChange` event, so the formula flashed from zero to full size and consumers couldn't reserve space in the same frame ([RN recommends `useLayoutEffect` for exactly this](https://reactnative.dev/docs/the-new-architecture/layout-measurements)).

The fix gives the Fabric shadow node a **synchronous Yoga measure** backed by the (thread-safe) engine, so the view has its real intrinsic size on the **first commit** — like `<Text>` or a sized `<Image>`. Measurement only parses the formula; it needs no fonts and doesn't touch the main thread's render path.

## iOS

Add `RaTeXMeasure` (a thread-safe synchronous measurer) and a measuring shadow node (`LeafYogaNode` + `MeasurableYogaNode` + `measureContent`), and point the `RaTeXView` component descriptor at it. `facebook::react::Size` is fully qualified to avoid ambiguity with `MacTypes.h`'s global `Size`.

## Android — why the extra C++

Android's `RaTeXViewManager` is a codegen `SimpleViewManager`, which has **no Yoga measure function** — its `onMeasure` doesn't feed the Fabric shadow-tree layout that `ref.measure()` reads, so the size can only arrive asynchronously. On Fabric/Android the only way to make a view self-measure synchronously is a **custom C++ shadow node** whose `measureContent` calls back to the platform via `FabricUIManager.measure → ViewManager.measure` — there is no Kotlin-only or codegen-only path. See the RN new-architecture guide on custom measurement:

- Software Mansion — *The New Architecture: The Tricky Parts (3/4)*: https://blog.swmansion.com/react-natives-new-architecture-the-tricky-parts-3-4-c4638c65927c
- RN docs — *Fabric Native Components*: https://reactnative.dev/docs/fabric-native-components-introduction


## Verified on device (New Arch, iOS + Android)

`ref.measure()` inside `useLayoutEffect` on the first commit:

| | iOS | Android — before | Android — after |
|---|---|---|---|
| `x = \frac{-b \pm \sqrt{b^2-4ac}}{2a}` | 267×68 | **0×0** | 267×69 |
| `\sum \frac{1}{n^2} = \frac{\pi^2}{6}` | 163×92 | — | 163×93 |

(1px height delta on Android is the existing glyph vertical-bleed adjustment.)

<img width="882" height="935" alt="image" src="https://github.com/user-attachments/assets/c174e3d6-c120-4eec-a294-7d89e02e8a12" />


## Notes

- Scope: New Architecture, `RaTeXView`. The existing async `onContentSizeChange` path is unchanged and stays consistent — it re-applies the same engine-derived size, so the two mechanisms don't conflict; the fix simply makes the first commit correct.
- No public API change.
