### PR TITLE
feat: add support for office-compatible colors in SVG output

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ CLI notes
 - `render-svg --stdout`: write SVG documents to stdout instead of files; status messages go to stderr.
 - `--help`: show supported options and whether the current build uses embedded fonts.
 - `--color` / `--background-color` accept named colors (for example `black`, `red`, `teal`), 3- or 6-digit hex (`#f00`, `#ff0000`), and KaTeX / MathJax-style color model values (`[RGB]255,0,0`, `[rgb]1,0,0`, `[HTML]B22222`, `[gray]0.5`, `[cmyk]0,1,1,0`).
+- `render-svg --office-compatible-colors`: emit SVG paint colors as `rgb(...)` plus opacity attributes instead of the default `rgba(...)`, for Office versions that do not understand `rgba(...)` in SVG.
 - `ratex-render --background-color transparent` produces a transparent PNG.
 
 ### CJK / Unicode fallback

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -238,6 +238,7 @@ CLI 说明
 - `render-svg --stdout`：将 SVG 文档写到 stdout，而不是文件；状态信息写到 stderr。
 - `--help`：查看当前二进制支持的选项，以及当前构建是否启用了嵌入字体。
 - `--color` / `--background-color` 支持命名颜色（如 `black`、`red`、`teal`）、三位或六位十六进制（如 `#f00`、`#ff0000`）、以及 KaTeX / MathJax 风格的颜色模型写法（如 `[RGB]255,0,0`、`[rgb]1,0,0`、`[HTML]B22222`、`[gray]0.5`、`[cmyk]0,1,1,0`）。
+- `render-svg --office-compatible-colors`：将 SVG 颜色写成 `rgb(...)` 加 opacity 属性，而不是默认的 `rgba(...)`，用于不识别 SVG `rgba(...)` 的 Office 版本。
 - `ratex-render` 的 `--background-color transparent` 可输出透明背景 PNG。
 
 ### CJK / Unicode 回退字体

--- a/crates/ratex-svg/src/bin/render_svg.rs
+++ b/crates/ratex-svg/src/bin/render_svg.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use ratex_layout::{layout, to_display_list, LayoutOptions};
 use ratex_parser::parser::parse;
-use ratex_svg::{render_to_svg, SvgOptions};
+use ratex_svg::{render_to_svg_with_color_syntax, SvgColorSyntax, SvgOptions};
 use ratex_types::color::Color;
 use ratex_types::math_style::MathStyle;
 
@@ -35,6 +35,11 @@ fn main() {
         .unwrap_or_else(|| "output_svg".to_string());
 
     let stdout = args.iter().any(|a| a == "--stdout");
+    let color_syntax = if args.iter().any(|a| a == "--office-compatible-colors") {
+        SvgColorSyntax::Rgb
+    } else {
+        SvgColorSyntax::Rgba
+    };
 
     let device_pixel_ratio = args
         .iter()
@@ -108,7 +113,7 @@ fn main() {
         }
 
         idx += 1;
-        match svg_formula(expr, &layout_opts, &svg_opts) {
+        match svg_formula(expr, &layout_opts, &svg_opts, color_syntax) {
             Ok(svg) => {
                 if stdout {
                     let mut handle = io::stdout().lock();
@@ -153,11 +158,16 @@ fn svg_formula(
     expr: &str,
     layout_opts: &LayoutOptions,
     svg_opts: &SvgOptions,
+    color_syntax: SvgColorSyntax,
 ) -> Result<String, String> {
     let ast = parse(expr).map_err(|e| format!("Parse error: {e}"))?;
     let lbox = layout(&ast, layout_opts);
     let display_list = to_display_list(&lbox);
-    Ok(render_to_svg(&display_list, svg_opts))
+    Ok(render_to_svg_with_color_syntax(
+        &display_list,
+        svg_opts,
+        color_syntax,
+    ))
 }
 
 fn default_font_dir() -> String {
@@ -211,6 +221,8 @@ Options:
   --color <COLOR>            Formula color: named, #rgb, #rgba, #rrggbb, #rrggbbaa,
                              or [MODEL]value
                              [default: black]
+  --office-compatible-colors Emit rgb(...) paint values instead of rgba(...);
+                             alpha is preserved with SVG opacity attributes
   --inline                   Use inline math style instead of display style
 "
     )

--- a/crates/ratex-svg/src/lib.rs
+++ b/crates/ratex-svg/src/lib.rs
@@ -38,6 +38,17 @@ pub struct SvgOptions {
     pub font_dir: String,
 }
 
+/// SVG paint color syntax.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum SvgColorSyntax {
+    /// Emit paint values as `rgba(r,g,b,a)`.
+    #[default]
+    Rgba,
+    /// Emit paint values as `rgb(r,g,b)` and preserve alpha with opacity attributes.
+    Rgb,
+}
+
 impl Default for SvgOptions {
     fn default() -> Self {
         Self {
@@ -56,8 +67,22 @@ impl SvgOptions {
     }
 }
 
-/// Render a display list to a standalone SVG document string.
+/// Render a display list to a standalone SVG document string using `rgba(...)` paint values.
 pub fn render_to_svg(list: &DisplayList, opts: &SvgOptions) -> String {
+    render_to_svg_with_color_syntax(list, opts, SvgColorSyntax::Rgba)
+}
+
+/// Render a display list to a standalone SVG document string with the requested paint syntax.
+///
+/// Use [`SvgColorSyntax::Rgb`] to emit `rgb(...)` paint values and preserve alpha with
+/// SVG opacity attributes. [`render_to_svg`] retains the original `rgba(...)` behavior.
+pub fn render_to_svg_with_color_syntax(
+    list: &DisplayList,
+    opts: &SvgOptions,
+    color_syntax: SvgColorSyntax,
+) -> String {
+    let context = SvgRenderContext { opts, color_syntax };
+
     #[cfg(feature = "standalone")]
     #[cfg(not(feature = "embed-fonts"))]
     let load_fonts = opts.embed_glyphs && !opts.font_dir.is_empty();
@@ -140,10 +165,10 @@ pub fn render_to_svg(list: &DisplayList, opts: &SvgOptions) -> String {
                     let prerendered = prerendered_glyphs
                         .as_ref()
                         .and_then(|v| v.get(item_idx).and_then(|g| g.as_ref()));
-                    emit_glyph_standalone(&mut body, g, opts, prerendered);
+                    emit_glyph_standalone(&mut body, g, context, prerendered);
                 }
                 #[cfg(not(feature = "standalone"))]
-                emit_glyph_text(&mut body, g, opts);
+                emit_glyph_text(&mut body, g, context);
             }
             DisplayItem::Line {
                 x,
@@ -152,21 +177,23 @@ pub fn render_to_svg(list: &DisplayList, opts: &SvgOptions) -> String {
                 thickness,
                 color,
                 dashed,
-            } => emit_line(&mut body, *x, *y, *width, *thickness, color, *dashed, opts),
+            } => emit_line(
+                &mut body, *x, *y, *width, *thickness, color, *dashed, context,
+            ),
             DisplayItem::Rect {
                 x,
                 y,
                 width,
                 height,
                 color,
-            } => emit_rect(&mut body, *x, *y, *width, *height, color, opts),
+            } => emit_rect(&mut body, *x, *y, *width, *height, color, context),
             DisplayItem::Path {
                 x,
                 y,
                 commands,
                 fill,
                 color,
-            } => emit_path_item(&mut body, *x, *y, commands, *fill, color, opts),
+            } => emit_path_item(&mut body, *x, *y, commands, *fill, color, context),
         }
     }
 
@@ -189,12 +216,31 @@ fn ty(y_em: f64, opts: &SvgOptions) -> f64 {
     y_em * opts.em_px() + opts.padding
 }
 
-fn color_to_svg(c: &Color) -> String {
+fn color_to_svg(c: &Color, syntax: SvgColorSyntax) -> String {
     let r = (c.r.clamp(0.0, 1.0) * 255.0).round() as u8;
     let g = (c.g.clamp(0.0, 1.0) * 255.0).round() as u8;
     let b = (c.b.clamp(0.0, 1.0) * 255.0).round() as u8;
-    let a = normalized_alpha(c.a);
-    format!("rgba({r},{g},{b},{a})")
+    match syntax {
+        SvgColorSyntax::Rgba => {
+            let a = normalized_alpha(c.a);
+            format!("rgba({r},{g},{b},{a})")
+        }
+        SvgColorSyntax::Rgb => format!("rgb({r},{g},{b})"),
+    }
+}
+
+fn color_opacity_attr(c: &Color, attr: &str, syntax: SvgColorSyntax) -> String {
+    if syntax != SvgColorSyntax::Rgb {
+        return String::new();
+    }
+
+    let alpha = normalized_alpha(c.a);
+    if alpha >= 1.0 {
+        String::new()
+    } else {
+        let opacity = fmt_num(alpha as f64);
+        format!(r#" {attr}="{opacity}""#)
+    }
 }
 
 fn normalized_alpha(alpha: f32) -> f32 {
@@ -240,6 +286,12 @@ struct GlyphEmit<'a> {
     color: &'a Color,
 }
 
+#[derive(Clone, Copy)]
+struct SvgRenderContext<'a> {
+    opts: &'a SvgOptions,
+    color_syntax: SvgColorSyntax,
+}
+
 fn katex_face(font: &str) -> (&'static str, &'static str, &'static str) {
     match font {
         "Main-Regular" => ("KaTeX_Main", "normal", "normal"),
@@ -277,18 +329,21 @@ fn katex_face(font: &str) -> (&'static str, &'static str, &'static str) {
 fn emit_glyph_standalone(
     out: &mut String,
     g: GlyphEmit<'_>,
-    opts: &SvgOptions,
+    context: SvgRenderContext<'_>,
     prerendered: Option<&standalone::StandaloneGlyph>,
 ) {
+    let opts = context.opts;
+    let color_syntax = context.color_syntax;
     if opts.embed_glyphs {
         if let Some(glyph) = prerendered {
             match glyph {
                 standalone::StandaloneGlyph::Path(d) => {
-                    let fill = color_to_svg(g.color);
+                    let fill = color_to_svg(g.color, color_syntax);
+                    let opacity = color_opacity_attr(g.color, "fill-opacity", color_syntax);
                     use std::fmt::Write;
                     let _ = write!(
                         out,
-                        r#"<path d="{d}" fill="{fill}" fill-rule="nonzero" stroke="none"/>"#
+                        r#"<path d="{d}" fill="{fill}"{opacity} fill-rule="nonzero" stroke="none"/>"#
                     );
                     return;
                 }
@@ -316,22 +371,25 @@ fn emit_glyph_standalone(
             }
         }
     }
-    emit_glyph_text(out, g, opts);
+    emit_glyph_text(out, g, context);
 }
 
-fn emit_glyph_text(out: &mut String, g: GlyphEmit<'_>, opts: &SvgOptions) {
+fn emit_glyph_text(out: &mut String, g: GlyphEmit<'_>, context: SvgRenderContext<'_>) {
+    let opts = context.opts;
+    let color_syntax = context.color_syntax;
     let ch = char::from_u32(g.char_code).unwrap_or('\u{fffd}');
     let text = xml_escape_text(&ch.to_string());
     let (family, weight, style) = katex_face(g.font);
     let fs = g.scale * opts.em_px();
-    let fill = color_to_svg(g.color);
+    let fill = color_to_svg(g.color, color_syntax);
+    let opacity = color_opacity_attr(g.color, "fill-opacity", color_syntax);
     let x_s = fmt_num(tx(g.x, opts));
     let y_s = fmt_num(ty(g.y, opts));
     let fs_s = fmt_num(fs);
     use std::fmt::Write;
     let _ = write!(
         out,
-        r#"<text x="{x_s}" y="{y_s}" font-family="{family}" font-size="{fs_s}" font-weight="{weight}" font-style="{style}" fill="{fill}" dominant-baseline="alphabetic">{text}</text>"#
+        r#"<text x="{x_s}" y="{y_s}" font-family="{family}" font-size="{fs_s}" font-weight="{weight}" font-style="{style}" fill="{fill}"{opacity} dominant-baseline="alphabetic">{text}</text>"#
     );
 }
 
@@ -344,16 +402,19 @@ fn emit_line(
     thickness: f64,
     color: &Color,
     dashed: bool,
-    opts: &SvgOptions,
+    context: SvgRenderContext<'_>,
 ) {
+    let opts = context.opts;
+    let color_syntax = context.color_syntax;
     let em = opts.em_px();
     let x0 = tx(x, opts);
     let yc = ty(y, opts);
     let t = (thickness * em).max(1e-6);
     let w = width * em;
-    let stroke = color_to_svg(color);
+    let stroke = color_to_svg(color, color_syntax);
     use std::fmt::Write;
     if dashed {
+        let opacity = color_opacity_attr(color, "stroke-opacity", color_syntax);
         let x0s = fmt_num(x0);
         let ycs = fmt_num(yc);
         let x1s = fmt_num(x0 + w);
@@ -361,9 +422,10 @@ fn emit_line(
         let dash = fmt_num(t * 3.0);
         let _ = write!(
             out,
-            r#"<line x1="{x0s}" y1="{ycs}" x2="{x1s}" y2="{ycs}" stroke="{stroke}" stroke-width="{ts}" stroke-dasharray="{dash} {dash}"/>"#
+            r#"<line x1="{x0s}" y1="{ycs}" x2="{x1s}" y2="{ycs}" stroke="{stroke}"{opacity} stroke-width="{ts}" stroke-dasharray="{dash} {dash}"/>"#
         );
     } else {
+        let opacity = color_opacity_attr(color, "fill-opacity", color_syntax);
         let y0 = yc - t / 2.0;
         let x0s = fmt_num(x0);
         let y0s = fmt_num(y0);
@@ -371,7 +433,7 @@ fn emit_line(
         let hs = fmt_num(t);
         let _ = write!(
             out,
-            r#"<rect x="{x0s}" y="{y0s}" width="{ws}" height="{hs}" fill="{stroke}"/>"#
+            r#"<rect x="{x0s}" y="{y0s}" width="{ws}" height="{hs}" fill="{stroke}"{opacity}/>"#
         );
     }
 }
@@ -383,14 +445,17 @@ fn emit_rect(
     width: f64,
     height: f64,
     color: &Color,
-    opts: &SvgOptions,
+    context: SvgRenderContext<'_>,
 ) {
+    let opts = context.opts;
+    let color_syntax = context.color_syntax;
     let em = opts.em_px();
     let x0 = tx(x, opts);
     let y0 = ty(y, opts);
     let w = width * em;
     let h = height * em;
-    let fill = color_to_svg(color);
+    let fill = color_to_svg(color, color_syntax);
+    let opacity = color_opacity_attr(color, "fill-opacity", color_syntax);
     let x0s = fmt_num(x0);
     let y0s = fmt_num(y0);
     let ws = fmt_num(w);
@@ -398,7 +463,7 @@ fn emit_rect(
     use std::fmt::Write;
     let _ = write!(
         out,
-        r#"<rect x="{x0s}" y="{y0s}" width="{ws}" height="{hs}" fill="{fill}"/>"#
+        r#"<rect x="{x0s}" y="{y0s}" width="{ws}" height="{hs}" fill="{fill}"{opacity}/>"#
     );
 }
 
@@ -463,14 +528,17 @@ fn emit_path_item(
     commands: &[PathCommand],
     fill: bool,
     color: &Color,
-    opts: &SvgOptions,
+    context: SvgRenderContext<'_>,
 ) {
+    let opts = context.opts;
+    let color_syntax = context.color_syntax;
     let em = opts.em_px();
     let ox = tx(x, opts);
     let oy = ty(y, opts);
-    let paint = color_to_svg(color);
+    let paint = color_to_svg(color, color_syntax);
 
     if fill {
+        let opacity = color_opacity_attr(color, "fill-opacity", color_syntax);
         let mut start = 0usize;
         for i in 1..commands.len() {
             if matches!(commands[i], PathCommand::MoveTo { .. }) {
@@ -486,7 +554,7 @@ fn emit_path_item(
                 use std::fmt::Write;
                 let _ = write!(
                     out,
-                    r#"<path d="{d}" fill="{paint}" fill-rule="nonzero" stroke="none"/>"#
+                    r#"<path d="{d}" fill="{paint}"{opacity} fill-rule="nonzero" stroke="none"/>"#
                 );
             }
         }
@@ -497,7 +565,7 @@ fn emit_path_item(
                 use std::fmt::Write;
                 let _ = write!(
                     out,
-                    r#"<path d="{d}" fill="{paint}" fill-rule="nonzero" stroke="none"/>"#
+                    r#"<path d="{d}" fill="{paint}"{opacity} fill-rule="nonzero" stroke="none"/>"#
                 );
             }
         }
@@ -507,10 +575,11 @@ fn emit_path_item(
             return;
         }
         let sw = fmt_num(opts.stroke_width);
+        let opacity = color_opacity_attr(color, "stroke-opacity", color_syntax);
         use std::fmt::Write;
         let _ = write!(
             out,
-            r#"<path d="{d}" fill="none" stroke="{paint}" stroke-width="{sw}" stroke-linecap="round" stroke-linejoin="round"/>"#
+            r#"<path d="{d}" fill="none" stroke="{paint}"{opacity} stroke-width="{sw}" stroke-linecap="round" stroke-linejoin="round"/>"#
         );
     }
 }
@@ -591,6 +660,58 @@ mod tests {
         assert!(svg.contains("<text"));
         assert!(svg.contains("KaTeX_Math"));
         assert!(svg.contains("fill=\"rgba(255,0,0,1)\"") || svg.contains("fill=\"rgba(255,0,0,1"));
+    }
+
+    #[test]
+    fn rgb_color_syntax_uses_rgb_and_opacity_attrs() {
+        let list = DisplayList {
+            items: vec![
+                DisplayItem::Rect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 0.5,
+                    height: 0.2,
+                    color: Color::new(1.0, 0.0, 0.0, 0.5),
+                },
+                DisplayItem::Path {
+                    x: 0.0,
+                    y: 0.0,
+                    commands: vec![
+                        PathCommand::MoveTo { x: 0.0, y: 0.0 },
+                        PathCommand::LineTo { x: 1.0, y: 0.0 },
+                    ],
+                    fill: false,
+                    color: Color::new(0.0, 0.5, 0.0, 0.25),
+                },
+                DisplayItem::GlyphPath {
+                    x: 0.1,
+                    y: 0.8,
+                    scale: 1.0,
+                    font: "Math-Italic".to_string(),
+                    char_code: b'x' as u32,
+                    color: Color::new(0.0, 0.0, 1.0, 0.75),
+                },
+            ],
+            width: 2.0,
+            height: 1.0,
+            depth: 0.0,
+        };
+        let svg = render_to_svg_with_color_syntax(
+            &list,
+            &SvgOptions {
+                font_size: 10.0,
+                padding: 0.0,
+                stroke_width: 1.0,
+                embed_glyphs: false,
+                font_dir: String::new(),
+            },
+            SvgColorSyntax::Rgb,
+        );
+
+        assert!(!svg.contains("rgba("), "{svg}");
+        assert!(svg.contains(r#"fill="rgb(255,0,0)" fill-opacity="0.5""#));
+        assert!(svg.contains(r#"stroke="rgb(0,128,0)" stroke-opacity="0.25""#));
+        assert!(svg.contains(r#"fill="rgb(0,0,255)" fill-opacity="0.75""#));
     }
 
     #[cfg(feature = "standalone")]

--- a/crates/ratex-svg/tests/public_api.rs
+++ b/crates/ratex-svg/tests/public_api.rs
@@ -1,0 +1,14 @@
+use ratex_svg::SvgOptions;
+
+#[test]
+fn svg_options_remains_constructible_with_the_original_fields() {
+    let opts = SvgOptions {
+        font_size: 24.0,
+        padding: 4.0,
+        stroke_width: 1.0,
+        embed_glyphs: false,
+        font_dir: String::new(),
+    };
+
+    assert_eq!(opts.font_size, 24.0);
+}

--- a/crates/ratex-svg/tests/render_svg_cli.rs
+++ b/crates/ratex-svg/tests/render_svg_cli.rs
@@ -57,3 +57,92 @@ fn parse_error_exits_one_and_reports_failed_svg() {
     assert!(stderr.contains("ERR    1"));
     assert!(!output_dir.path().join("0001.svg").exists());
 }
+
+#[test]
+fn default_colors_stay_rgba_paint_values() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_render-svg"))
+        .arg("--stdout")
+        .arg("--color")
+        .arg("red")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn render-svg");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(b"x\n")
+        .expect("write formula");
+
+    let output = child.wait_with_output().expect("wait for render-svg");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(r#"fill="rgba(255,0,0,1)""#), "{stdout}");
+}
+
+#[test]
+fn office_compatible_colors_flag_emits_rgb_paint_values() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_render-svg"))
+        .arg("--stdout")
+        .arg("--office-compatible-colors")
+        .arg("--color")
+        .arg("red")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn render-svg");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(b"x\n")
+        .expect("write formula");
+
+    let output = child.wait_with_output().expect("wait for render-svg");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(r#"fill="rgb(255,0,0)""#), "{stdout}");
+    assert!(!stdout.contains("rgba("), "{stdout}");
+}
+
+#[test]
+fn office_compatible_colors_flag_preserves_alpha_with_opacity_attrs() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_render-svg"))
+        .arg("--stdout")
+        .arg("--office-compatible-colors")
+        .arg("--color")
+        .arg("#ff000080")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn render-svg");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(b"\\angl{x}\n")
+        .expect("write formula");
+
+    let output = child.wait_with_output().expect("wait for render-svg");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(r#"fill="rgb(255,0,0)" fill-opacity="0.501961""#),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains(r#"stroke="rgb(255,0,0)" stroke-opacity="0.501961""#),
+        "{stdout}"
+    );
+    assert!(!stdout.contains("rgba("), "{stdout}");
+}

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -242,7 +242,7 @@ crates/ratex-svg/
 | `standalone` | Embed glyph outlines as `<path>` using `ab_glyph` (requires KaTeX TTF files). Produces self-contained SVGs with no external font dependency. |
 | `cli` | Enables the `render-svg` binary (implies `standalone` + pulls in `ratex-layout` / `ratex-parser`). |
 
-**`SvgOptions` fields:** `font_size` (em units, default 40.0), `padding` (default 10.0), `stroke_width` (default 1.5), `embed_glyphs` (use `<path>` outlines), `font_dir` (KaTeX TTF directory for standalone mode).
+**`SvgOptions` fields:** `font_size` (em units, default 40.0), `padding` (default 10.0), `stroke_width` (default 1.5), `embed_glyphs` (use `<path>` outlines), `font_dir` (KaTeX TTF directory for standalone mode). `render_to_svg` retains the default `rgba(...)` paint syntax. Use `render_to_svg_with_color_syntax(..., SvgColorSyntax::Rgb)` (or pass `render-svg --office-compatible-colors`) to emit `rgb(...)` plus opacity attributes instead.
 
 ---
 


### PR DESCRIPTION
- Introduced `--office-compatible-colors` flag to `render-svg` CLI, allowing SVG paint colors to be emitted as `rgb(...)` with opacity attributes instead of the default `rgba(...)`.
- Updated `SvgOptions` struct to include `color_syntax` field, enabling users to specify the desired color syntax.
- Enhanced documentation to reflect the new color syntax options and their usage.