### PR TITLE
Expose color and displayMode parameters in RaTeXSpan.create()

### DIFF
--- a/platforms/android/src/main/kotlin/io/ratex/RaTeXSpan.kt
+++ b/platforms/android/src/main/kotlin/io/ratex/RaTeXSpan.kt
@@ -51,6 +51,7 @@ class RaTeXSpan private constructor(
          * @param displayMode `true` (default) for display/block style; `false` for inline/text style.
          * @throws RaTeXException if the formula cannot be parsed.
          */
+        @JvmOverloads
         suspend fun create(
             context: Context,
             latex: String,

--- a/platforms/android/src/main/kotlin/io/ratex/RaTeXSpan.kt
+++ b/platforms/android/src/main/kotlin/io/ratex/RaTeXSpan.kt
@@ -7,6 +7,8 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.text.style.ReplacementSpan
+import android.graphics.Color
+import androidx.annotation.ColorInt
 import kotlin.math.ceil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -42,15 +44,23 @@ class RaTeXSpan private constructor(
          * Font loading and rendering run on [Dispatchers.IO]. Call from a coroutine or
          * `suspend` function; the result is delivered on the caller's dispatcher.
          *
-         * @param context  Any context; used only for asset access during font loading.
-         * @param latex    LaTeX math-mode string (no surrounding `$` or `\[…\]`).
-         * @param fontSize Font size in **dp** (density-independent pixels). Converted to px internally.
+         * @param context     Any context; used only for asset access during font loading.
+         * @param latex       LaTeX math-mode string (no surrounding `$` or `\[…\]`).
+         * @param fontSize    Font size in **dp** (density-independent pixels). Converted to px internally.
+         * @param color       Text color as an ARGB integer (default [Color.BLACK]).
+         * @param displayMode `true` (default) for display/block style; `false` for inline/text style.
          * @throws RaTeXException if the formula cannot be parsed.
          */
-        suspend fun create(context: Context, latex: String, fontSize: Float): RaTeXSpan =
+        suspend fun create(
+            context: Context,
+            latex: String,
+            fontSize: Float,
+            @ColorInt color: Int = Color.BLACK,
+            displayMode: Boolean = true,
+        ): RaTeXSpan =
             withContext(Dispatchers.IO) {
                 RaTeXFontLoader.ensureLoaded(context)
-                val dl = RaTeXEngine.parse(latex)
+                val dl = RaTeXEngine.parse(latex, displayMode, color)
                 val fontSizePx = fontSize * context.resources.displayMetrics.density
                 val renderer = RaTeXRenderer(dl, fontSizePx) { RaTeXFontLoader.getTypeface(it) }
 


### PR DESCRIPTION
## Summary

Expose `color` and `displayMode` parameters in `RaTeXSpan.create()` so
callers can specify formula color and block/inline rendering mode.

## Motivation

`RaTeXSpan` currently hard-codes the default color to black and always
uses display (block) mode. Users who need dark/light theme switching or
inline formulas must reimplement the span themselves.

`RaTeXEngine.parse()` already supports both `color` and `displayMode`
parameters — this change simply threads them through `RaTeXSpan.create()`.

## Changes

- `platforms/android/src/main/kotlin/io/ratex/RaTeXSpan.kt`:
  - Add `@ColorInt color: Int = Color.BLACK` parameter
  - Add `displayMode: Boolean = true` parameter
  - Forward both to `RaTeXEngine.parse(latex, displayMode, color)`
  - Update KDoc with `@param` entries for the new parameters

The existing `create(context, latex, fontSize)` signature continues to
work unchanged due to default parameter values.

## Testing

- Code review: additive change (two new parameters with defaults), does not
  break existing callers, and follows the same pattern already used by
  `RaTeXEngine.parse()`.
- CI: compilation verified by GitHub Actions on push.

## Related issue

Fixes #113
