### PR TITLE
feat(react-native): baseline alignment + `getTexMetrics()`

### DIFF
--- a/demo/react-native-expo/App.tsx
+++ b/demo/react-native-expo/App.tsx
@@ -27,7 +27,8 @@ import {
   useWindowDimensions,
   ScrollView,
 } from "react-native";
-import { InlineTeX, RaTeXView } from "ratex-react-native";
+import { InlineTeX, RaTeXView, getTexMetrics } from "ratex-react-native";
+import type { RaTeXTexMetrics, RaTeXViewRef } from "ratex-react-native";
 
 const EXPR = String.raw`x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}`;
 const EXPR2 = String.raw`\sum_{n=1}^{\infty} \frac{1}{n^2} = \frac{\pi^2}{6}`;
@@ -1123,6 +1124,170 @@ function CaseYogaAligns() {
   );
 }
 
+// ─── ref.getTexMetrics(): drawn ink baseline for custom hosts ────────────────
+//
+// Hosts that do their own layout (markdown engines placing formulas over a
+// custom text view, canvas typesetters) can't use flex baseline or <Text>.
+// getTexMetrics() hands them the placement numbers synchronously in
+// useLayoutEffect. The green ruler is positioned purely from the returned
+// depth — it must kiss the ink baseline at every clamp width, because depth
+// is DRAWN: fit-scale and centering gap for the committed frame are already
+// applied (drawnDepth = gap + naturalDepth × scale).
+const METRICS_LATEX = String.raw`\int_0^\infty e^{-x^2}\,dx = \frac{\sqrt{\pi}}{2}`;
+const METRICS_WIDTHS = [undefined, 200, 140, 90] as const;
+
+function TexMetricsRow({ maxWidth }: { maxWidth?: number }) {
+  const ref = useRef<RaTeXViewRef>(null);
+  const [probe, setProbe] = useState<{
+    metrics: RaTeXTexMetrics;
+    frameHeight: number;
+  } | null>(null);
+
+  useLayoutEffect(() => {
+    const metrics = ref.current?.getTexMetrics();
+    let frameHeight = 0;
+    ref.current?.measure((_x, _y, _w, h) => {
+      frameHeight = h; // sync on Fabric
+    });
+    setProbe(metrics && frameHeight > 0 ? { metrics, frameHeight } : null);
+  }, [maxWidth]);
+
+  return (
+    <View style={styles.metricsRow}>
+      <View style={styles.metricsBox}>
+        <RaTeXView
+          ref={ref}
+          latex={METRICS_LATEX}
+          fontSize={24}
+          displayMode={false}
+          color="#111827"
+          style={{ alignSelf: "flex-start", maxWidth }}
+        />
+        {probe && (
+          <View
+            style={[
+              styles.metricsBaseline,
+              { top: probe.frameHeight - probe.metrics.depth },
+            ]}
+          />
+        )}
+      </View>
+      <Text style={styles.metricsLabel}>
+        {maxWidth ? `maxWidth ${maxWidth}` : "natural"}
+        {probe
+          ? ` · scale ${probe.metrics.scale.toFixed(2)} · depth ${probe.metrics.depth.toFixed(1)}`
+          : " · …"}
+      </Text>
+    </View>
+  );
+}
+
+function CaseTexMetrics() {
+  return (
+    <View style={[styles.card, styles.inlineCard]}>
+      <View style={styles.cardHeader}>
+        <Text style={styles.cardTitle}>
+          ref.getTexMetrics(): ink baseline for custom hosts
+        </Text>
+      </View>
+      <Text style={styles.smokeHint}>
+        The green ruler is placed only from getTexMetrics().depth (top =
+        frameHeight − depth). It must sit on the ink baseline in every row —
+        including the clamped ones, where the drawn depth shrinks with scale.
+      </Text>
+      <View style={styles.inlineBody}>
+        {METRICS_WIDTHS.map((w) => (
+          <TexMetricsRow key={w ?? "natural"} maxWidth={w} />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+// ─── getTexMetrics() perf: uncached vs cached, N unique formulas ─────
+const PERF_SIZES = [10, 50, 100, 200];
+const PERF_REPS = 5;
+
+// Every formula has the SAME shape/size (unique only via the embedded
+// nonce/index digits) so per-formula cost is comparable across N.
+function makePerfFormulas(n: number, nonce: number): string[] {
+  return Array.from(
+    { length: n },
+    (_, i) =>
+      String.raw`\frac{${nonce}x_{${i}} + \sqrt{${(i % 7) + 2}}}{y^{${(i % 5) + 2}} - ${nonce}} + \sum_{k=1}^{${(i % 4) + 2}} k^{${(i % 3) + 2}}`,
+  );
+}
+
+function median(xs: number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  return s[Math.floor(s.length / 2)];
+}
+
+type PerfRow = { n: number; uncachedMs: number; cachedMs: number; failed: number };
+
+function CaseTexMetricsPerf() {
+  const [rows, setRows] = useState<PerfRow[] | null>(null);
+  const nonceRef = useRef(1);
+
+  const run = useCallback(() => {
+    // Warmup: ramps the CPU governor and JIT before anything is timed.
+    for (const f of makePerfFormulas(100, nonceRef.current++)) {
+      getTexMetrics(f, 16, false);
+    }
+    const out: PerfRow[] = [];
+    for (const n of PERF_SIZES) {
+      const uncached: number[] = [];
+      const cached: number[] = [];
+      let failed = 0;
+      for (let rep = 0; rep < PERF_REPS; rep++) {
+        const formulas = makePerfFormulas(n, nonceRef.current++);
+        const t0 = performance.now();
+        for (const f of formulas) {
+          if (!getTexMetrics(f, 16, false)) failed++;
+        }
+        const t1 = performance.now();
+        for (const f of formulas) {
+          getTexMetrics(f, 16, false);
+        }
+        uncached.push(t1 - t0);
+        cached.push(performance.now() - t1);
+      }
+      out.push({
+        n,
+        uncachedMs: median(uncached),
+        cachedMs: median(cached),
+        failed,
+      });
+    }
+    setRows(out);
+  }, []);
+
+  return (
+    <View style={[styles.card, styles.inlineCard]}>
+      <View style={styles.cardHeader}>
+        <Text style={styles.cardTitle}>getTexMetrics() perf (global)</Text>
+      </View>
+      <Text style={styles.smokeHint}>
+        Warmup, then per N: 5 reps of (N unique formulas cold, same N again
+        cached); medians shown. Parse cache holds 128 entries — at N=200 the
+        second pass thrashes the LRU, so "cached" ≈ uncached there.
+      </Text>
+      <Pressable style={styles.button} onPress={run}>
+        <Text style={styles.buttonText}>Run perf test</Text>
+      </Pressable>
+      {rows && (
+        <View style={{ paddingHorizontal: 12, paddingBottom: 12 }}>
+          {rows.map((r) => (
+            <Text key={r.n} style={styles.perfLine}>
+              {`N=${String(r.n).padStart(3)}  uncached ${r.uncachedMs.toFixed(1)}ms (${(r.uncachedMs / r.n).toFixed(2)}/f)  cached ${r.cachedMs.toFixed(1)}ms (${(r.cachedMs / r.n).toFixed(3)}/f)${r.failed ? `  failed=${r.failed}` : ""}`}
+            </Text>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
 // ─── Case C: Explicit dimensions (control — should always work) ─────
 function CaseExplicit({ renderKey }: { renderKey: number }) {
   const [status, setStatus] = useState<"pending" | "ok" | "error">("pending");
@@ -1188,6 +1353,8 @@ export default function App() {
         <CaseInlineFontMix />
         <CaseInlineMaxWidth />
         <CaseYogaAligns />
+        <CaseTexMetrics />
+        <CaseTexMetricsPerf />
 
         <View style={styles.cases}>
           <CaseFlexMinHeight renderKey={key} />
@@ -1488,6 +1655,33 @@ const styles = StyleSheet.create({
     color: "#6b7280",
     fontFamily: "Menlo",
     marginTop: 2,
+  },
+  metricsRow: {
+    paddingVertical: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#e5e7eb",
+  },
+  metricsBox: {
+    alignSelf: "flex-start",
+  },
+  metricsBaseline: {
+    position: "absolute",
+    left: -8,
+    right: -8,
+    height: 1,
+    backgroundColor: "#ffb981",
+  },
+  metricsLabel: {
+    fontSize: 11,
+    color: "#6b7280",
+    fontFamily: "Menlo",
+    marginTop: 4,
+  },
+  perfLine: {
+    fontSize: 11,
+    color: "#111827",
+    fontFamily: "Menlo",
+    marginTop: 4,
   },
   inlineParaText: {
     fontSize: INLINE_BASELINE_FONT_SIZE,

--- a/demo/react-native-expo/App.tsx
+++ b/demo/react-native-expo/App.tsx
@@ -15,6 +15,8 @@
 
 import { StatusBar } from "expo-status-bar";
 import { useState, useCallback, useLayoutEffect, useRef } from "react";
+import type { ReactNode } from "react";
+import type { ViewStyle } from "react-native";
 import {
   StyleSheet,
   Text,
@@ -614,6 +616,513 @@ function CaseInlineTeXCustomFont() {
   );
 }
 
+// ─── Inline baseline: RaTeXView in <Text> vs alignItems:'baseline' row ──
+//
+// Two embeddings of the same `$…$` fixtures, both using RaTeXView only:
+//
+// Red border — formulas embedded in <Text>: RN places an inline view with its
+// BOTTOM on the text baseline, so any formula with descent ($y$, $y_i$,
+// $\frac{a}{b}$…) floats UP by exactly that descent (current default).
+//
+// Blue border — word-level <Text> and RaTeXView siblings in a wrapping flex row
+// with alignItems:'baseline': Yoga aligns children by baseline. Text provides a
+// real one (ParagraphShadowNode::baseline); RaTeXView does not yet, so Yoga
+// falls back to its bottom edge and the row shows the SAME float-up — until the
+// native shadow-node baseline() lands, after which blue rows must align
+// perfectly (the descender-twins line makes it obvious).
+const INLINE_BASELINE_FONT_SIZE = 16;
+const INLINE_BASELINE_PARAS = [
+  String.raw`No descent at all: $x^2 + 1$ and $a + b = c$ should sit exactly like words.`,
+  String.raw`Descender twins — compare y with $y$, p with $p$, g with $g$, q with $q$ in one line.`,
+  String.raw`Subscripts hang below: $y_i$, deeper $a_{i_j}$, and chained $x_{n+1} = x_n - f(x_n)/f'(x_n)$ mid-sentence.`,
+  String.raw`A fraction $\frac{a}{b}$ between words, a taller one $\frac{x^2+1}{x-1}$ next, and the quadratic $x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$ to finish the line.`,
+  String.raw`Radicals: plain $\sqrt{2}$, stacked $\sqrt{1 + \sqrt{x}}$, and with a descender inside $\sqrt{y_j}$.`,
+  String.raw`Operators stay inline-styled: sum $\sum_{n=1}^{\infty} \frac{1}{n^2}$, integral $\int_0^1 x\,dx$, limit $\lim_{x \to 0} \frac{\sin x}{x} = 1$.`,
+  String.raw`Tall ascent, no descent: $e^{x^2}$ and $2^{2^n}$ should not float above the line.`,
+  String.raw`Big delimiters both ways: $\left(\frac{1}{1+x}\right)^2$ and $\left[\sum_k a_k\right]$ inside running text.`,
+];
+
+/** Renders a `$…$` paragraph as RN <Text> with RaTeXView children — the way a
+ * markdown renderer embeds formulas. With alignSelf:'baseline' in the style
+ * the view translates itself down by the engine-exact descent (sync metrics,
+ * no probes) — the same style that baseline-aligns it as a flex sibling. */
+function InlineDefaultParagraph({
+  source,
+  alignBaseline,
+}: {
+  source: string;
+  alignBaseline?: boolean;
+}) {
+  // Even indices are plain text, odd indices are formula bodies.
+  const parts = source.split(/\$([^$]+)\$/g);
+  return (
+    <Text selectable style={styles.inlineParaText}>
+      {parts.map((part, i) =>
+        i % 2 === 0 ? (
+          part
+        ) : (
+          <RaTeXView
+            key={i}
+            latex={part}
+            fontSize={INLINE_BASELINE_FONT_SIZE}
+            displayMode={false}
+            style={alignBaseline ? { alignSelf: "baseline" } : undefined}
+            color="#111827"
+          />
+        )
+      )}
+    </Text>
+  );
+}
+
+/** The same `$…$` paragraph as a wrapping flex row under alignItems:'baseline':
+ * every word is its own <Text> sibling so Yoga (not the text engine) owns
+ * placement and aligns each child by its baseline. */
+function InlineBaselineRowParagraph({ source }: { source: string }) {
+  const parts = source.split(/\$([^$]+)\$/g);
+  const children: ReactNode[] = [];
+  parts.forEach((part, i) => {
+    if (i % 2 === 1) {
+      children.push(
+        <RaTeXView
+          key={`m${i}`}
+          latex={part}
+          fontSize={INLINE_BASELINE_FONT_SIZE}
+          displayMode={false}
+          color="#111827"
+        />
+      );
+      return;
+    }
+    for (const [j, word] of part.split(/\s+/).filter(Boolean).entries()) {
+      children.push(
+        <Text selectable key={`t${i}-${j}`} style={styles.inlineParaText}>
+          {word}
+        </Text>
+      );
+    }
+  });
+  return <View style={styles.inlineBaselineRow}>{children}</View>;
+}
+
+function CaseInlineBaseline() {
+  return (
+    <View style={[styles.card, styles.inlineCard]}>
+      <View style={styles.cardHeader}>
+        <Text style={styles.cardTitle}>
+          Inline baseline: {"<Text>"} embed vs alignItems:'baseline'
+        </Text>
+      </View>
+      <Text style={styles.smokeHint}>
+        Amber and blue should match; red floats up. Watch the descender-twins
+        line.
+      </Text>
+      <View style={styles.inlineLegend}>
+        <Text style={[styles.inlineLegendLine, { color: "#ef4444" }]}>
+          {"<Text>bla <RaTeXView/> bla</Text>"}
+        </Text>
+        <Text style={[styles.inlineLegendLine, { color: "#f59e0b" }]}>
+          {"<Text>bla <RaTeXView style={{alignSelf:'baseline'}}/> bla</Text>"}
+        </Text>
+        <Text style={[styles.inlineLegendLine, { color: "#3b82f6" }]}>
+          {"<View style={{flexDirection:'row', alignItems:'baseline'}}>\n  <Text>bla</Text> <RaTeXView/> ...\n</View>"}
+        </Text>
+      </View>
+      <View style={styles.inlineBody}>
+        {INLINE_BASELINE_PARAS.map((para, i) => (
+          <View key={i} style={styles.inlinePair}>
+            <View style={[styles.inlineRow, styles.inlineRowDefault]}>
+              <InlineDefaultParagraph source={para} />
+            </View>
+            <View style={[styles.inlineRow, styles.inlineRowAligned]}>
+              <InlineDefaultParagraph source={para} alignBaseline />
+            </View>
+            <View style={[styles.inlineRow, styles.inlineRowBaseline]}>
+              <InlineBaselineRowParagraph source={para} />
+            </View>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+// ─── Baseline with a text line ABOVE the math line (3-line paragraphs) ────────
+//
+// Same three variants as the inline-baseline card, but each paragraph opens
+// with a plain-text line, so the math line has a text neighbor above AND below.
+// Exposes what the alignment approach does to interline spacing around a tall
+// aligned formula.
+const NEIGHBOR_PARAS = [
+  String.raw`This opening line is plain running. Big delimiters both ways: $\left(\frac{1}{1+x}\right)^2$ and $\left[\sum_k a_k\right]$ inside running text.`,
+  String.raw`This opening line is plain running. Big delimiters both ways: $\left[\sum_k a_k\right]$ inside running text.`,
+];
+
+function CaseInlineBaselineNeighbors() {
+  return (
+    <View style={[styles.card, styles.inlineCard]}>
+      <View style={styles.cardHeader}>
+        <Text style={styles.cardTitle}>
+          Baseline with a plain text line above (3-line wrap)
+        </Text>
+      </View>
+      <Text style={styles.smokeHint}>
+        Line 1 is text only; the tall formulas sit on line 2. Compare the
+        spacing between lines 1–2 and 2–3 across the three variants.
+      </Text>
+      <View style={styles.inlineBody}>
+        {NEIGHBOR_PARAS.map((para, i) => (
+          <View key={i} style={styles.inlinePair}>
+            <View style={[styles.inlineRow, styles.inlineRowDefault]}>
+              <InlineDefaultParagraph source={para} />
+            </View>
+            <View style={[styles.inlineRow, styles.inlineRowAligned]}>
+              <InlineDefaultParagraph source={para} alignBaseline />
+            </View>
+            <View style={[styles.inlineRow, styles.inlineRowBaseline]}>
+              <InlineBaselineRowParagraph source={para} />
+            </View>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+// ─── KNOWN ISSUE (not fixable): deep descender overdraws the next line ───────
+//
+// RN's text engine reserves only the run font's descender BELOW the baseline —
+// an inline view has no way to ask for more (the attachment protocol carries no
+// depth). A formula whose descent far exceeds the text descender therefore
+// overdraws the following line in <Text> (amber), while a baseline flex row
+// reserves the full depth and pushes the next line down (blue). Fixing this
+// needs RN itself to learn attachment depth; everything above the baseline IS
+// fixed (ascent-only measure).
+const DEEP_PARAS = [
+  String.raw`This opening line is plain running text with no math in it at all. A very deep tail mid-line: $x = \cfrac{1}{2+\cfrac{1}{3+\cfrac{1}{4+y}}}$ splits the sentence, and this trailing text wraps onto the line right below the formula's descender.`,
+];
+
+function CaseDeepDescenderOverdraw() {
+  return (
+    <View style={[styles.card, styles.inlineCard]}>
+      <View style={styles.cardHeader}>
+        <Text style={styles.cardTitle}>
+          Known issue (not fixable): deep descender overdraws the next line
+        </Text>
+      </View>
+      <Text style={styles.smokeHint}>
+        The continued fraction descends far below the text descender. Amber
+        (in-Text): RN reserves only the font descender below the baseline, so
+        the tail overdraws line 3. Blue (flex): the row reserves the full depth
+        and line 3 moves down. Needs RN-side attachment depth to fix.
+      </Text>
+      <View style={styles.inlineBody}>
+        {DEEP_PARAS.map((para, i) => (
+          <View key={i} style={styles.inlinePair}>
+            <View style={[styles.inlineRow, styles.inlineRowAligned]}>
+              <InlineDefaultParagraph source={para} alignBaseline />
+            </View>
+            <View style={[styles.inlineRow, styles.inlineRowBaseline]}>
+              <InlineBaselineRowParagraph source={para} />
+            </View>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+// ─── In-<Text> alignSelf options: none / baseline / center / start / end ─────
+//
+// Inside <Text> the text engine pins an inline view's bottom to the baseline;
+// the native view then offsets its own ink per style.alignSelf: 'baseline' is
+// engine-exact, 'center' centers the box on the TeX math axis, 'flex-start' /
+// 'flex-end' approximate text-top / text-bottom from the em. Same sentence per
+// row — only alignSelf on the formulas changes.
+const INLINE_ALIGN_OPTIONS = [
+  undefined,
+  "baseline",
+  "center",
+  "flex-start",
+  "flex-end",
+] as const;
+
+function CaseInlineAlignOptions() {
+  return (
+    <View style={[styles.card, styles.inlineCard]}>
+      <View style={styles.cardHeader}>
+        <Text style={styles.cardTitle}>In-Text alignSelf options</Text>
+      </View>
+      <Text style={styles.smokeHint}>
+        One sentence per option — only style.alignSelf on the formulas changes.
+      </Text>
+      <View style={styles.inlineBody}>
+        {INLINE_ALIGN_OPTIONS.map((align) => (
+          <View key={align ?? "none"} style={styles.inlinePair}>
+            <Text style={[styles.inlineLegendLine, { color: "#6b7280" }]}>
+              {align ? `alignSelf: '${align}'` : "(no alignSelf)"}
+            </Text>
+            <Text style={styles.inlineParaText}>
+              gap py{" "}
+              <RaTeXView
+                latex={String.raw`\sqrt{y_j}`}
+                fontSize={INLINE_BASELINE_FONT_SIZE}
+                displayMode={false}
+                style={align ? { alignSelf: align } : undefined}
+                color="#111827"
+              />{" "}
+              mid{" "}
+              <RaTeXView
+                latex={String.raw`\frac{x^2+1}{x-1}`}
+                fontSize={INLINE_BASELINE_FONT_SIZE}
+                displayMode={false}
+                style={align ? { alignSelf: align } : undefined}
+                color="#111827"
+              />{" "}
+              end gy
+            </Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+// ─── Baseline × font size mix: alignment must be fontSize-independent ─────
+//
+// The shift is computed from the formula's own metrics at its own fontSize, so
+// it must hold when text and math sizes differ (the text engine pins the view
+// bottom to the baseline regardless of either size). Amber (in <Text>) and
+// blue (flex baseline row) must match in every combination.
+const FONT_MIX_CASES = [
+  { label: "text 32 / math 32", text: 32, math: 32 },
+  { label: "text 32 / math 16", text: 32, math: 16 },
+  { label: "text 16 / math 32", text: 16, math: 32 },
+];
+
+function CaseInlineFontMix() {
+  return (
+    <View style={[styles.card, styles.inlineCard]}>
+      <View style={styles.cardHeader}>
+        <Text style={styles.cardTitle}>Baseline × font size mix</Text>
+      </View>
+      <Text style={styles.smokeHint}>
+        alignSelf:'baseline' with differing text/math sizes — amber and blue
+        must match in every combination.
+      </Text>
+      <View style={styles.inlineBody}>
+        {FONT_MIX_CASES.map(({ label, text, math }) => (
+          <View key={label} style={styles.inlinePair}>
+            <Text style={[styles.inlineLegendLine, { color: "#6b7280" }]}>
+              {label}
+            </Text>
+            <View style={[styles.inlineRow, styles.inlineRowAligned]}>
+              <Text style={[styles.inlineParaText, { fontSize: text }]}>
+                gap py{" "}
+                <RaTeXView
+                  latex={String.raw`\sqrt{y_j}`}
+                  fontSize={math}
+                  displayMode={false}
+                  style={{ alignSelf: "baseline" }}
+                  color="#111827"
+                />{" "}
+                mid{" "}
+                <RaTeXView
+                  latex={String.raw`\frac{x^2+1}{x-1}`}
+                  fontSize={math}
+                  displayMode={false}
+                  style={{ alignSelf: "baseline" }}
+                  color="#111827"
+                />{" "}
+                end gy
+              </Text>
+            </View>
+            <View style={[styles.inlineRow, styles.inlineRowBaseline]}>
+              <View style={styles.inlineBaselineRow}>
+                <Text style={[styles.inlineParaText, { fontSize: text }]}>
+                  gap py
+                </Text>
+                <RaTeXView
+                  latex={String.raw`\sqrt{y_j}`}
+                  fontSize={math}
+                  displayMode={false}
+                  color="#111827"
+                />
+                <Text style={[styles.inlineParaText, { fontSize: text }]}>
+                  mid
+                </Text>
+                <RaTeXView
+                  latex={String.raw`\frac{x^2+1}{x-1}`}
+                  fontSize={math}
+                  displayMode={false}
+                  color="#111827"
+                />
+                <Text style={[styles.inlineParaText, { fontSize: text }]}>
+                  end gy
+                </Text>
+              </View>
+            </View>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+// ─── maxWidth autoscaling × baseline ─────
+//
+// A width-clamped formula downscales its ink (fit-scale, never up) and centers
+// it inside the assigned box, so the ink baseline moves: the in-<Text> shift
+// must anchor the SCALED ink baseline plus the centering gap, and the flex
+// baseline() mirrors the same fit math. Control (unclamped) rows first.
+const MAXW_LATEX = String.raw`x = \frac{-b \pm \sqrt{b^2-4ac}}{2a}`;
+
+function MaxWidthPair({
+  label,
+  maxWidth,
+}: {
+  label: string;
+  maxWidth?: number;
+}) {
+  return (
+    <View style={styles.inlinePair}>
+      <Text style={[styles.inlineLegendLine, { color: "#6b7280" }]}>
+        {label}
+      </Text>
+      <View style={[styles.inlineRow, styles.inlineRowAligned]}>
+        <Text style={styles.inlineParaText}>
+          gap py{" "}
+          <RaTeXView
+            latex={MAXW_LATEX}
+            fontSize={INLINE_BASELINE_FONT_SIZE}
+            displayMode={false}
+            style={{ alignSelf: "baseline", maxWidth }}
+            color="#111827"
+          />{" "}
+          end gy
+        </Text>
+      </View>
+      <View style={[styles.inlineRow, styles.inlineRowBaseline]}>
+        <View style={styles.inlineBaselineRow}>
+          <Text style={styles.inlineParaText}>gap py</Text>
+          <RaTeXView
+            latex={MAXW_LATEX}
+            fontSize={INLINE_BASELINE_FONT_SIZE}
+            displayMode={false}
+            style={{ maxWidth }}
+            color="#111827"
+          />
+          <Text style={styles.inlineParaText}>end gy</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function CaseInlineMaxWidth() {
+  return (
+    <View style={[styles.card, styles.inlineCard]}>
+      <View style={styles.cardHeader}>
+        <Text style={styles.cardTitle}>maxWidth autoscaling × baseline</Text>
+      </View>
+      <Text style={styles.smokeHint}>
+        The clamped formula scales its ink down; the scaled baseline must still
+        sit on the text baseline in both host contexts.
+      </Text>
+      <View style={styles.inlineBody}>
+        <MaxWidthPair label="no clamp (control)" />
+        <MaxWidthPair label="maxWidth: 90 (≈0.6× ink scale)" maxWidth={90} />
+        <MaxWidthPair label="maxWidth: 60 (≈0.4× ink scale)" maxWidth={60} />
+      </View>
+    </View>
+  );
+}
+
+// ─── Yoga alignment variants: RaTeXView as a regular flex child ─────
+//
+// The shadow-node baseline() only changes what `baseline` alignment sees; every
+// other align value must keep its usual Yoga meaning. One row per value, with a
+// short-and-deep formula ($y_j$) and a tall fraction between text runs whose
+// descenders (g, p, y) make the baseline row easy to judge. The last row uses
+// alignSelf: 'baseline' per child (container centers) — per-child opt-in works
+// the same way as container-level alignItems.
+// Narrow style type: the RaTeXView style prop resolves against the symlinked
+// library's own react-native types, which structurally clash with the demo's on
+// unrelated fields (boxShadow) — a subset type is assignable to both.
+type ChildAlign = {
+  alignSelf?: "auto" | "flex-start" | "flex-end" | "center" | "stretch" | "baseline";
+};
+
+const ALIGN_SAMPLES: {
+  label: string;
+  container: ViewStyle;
+  child?: ChildAlign;
+}[] = [
+  { label: "alignItems: 'flex-start'", container: { alignItems: "flex-start" } },
+  { label: "alignItems: 'center'", container: { alignItems: "center" } },
+  { label: "alignItems: 'flex-end'", container: { alignItems: "flex-end" } },
+  { label: "alignItems: 'baseline'", container: { alignItems: "baseline" } },
+  {
+    label: "alignSelf: 'baseline' on each child, container centers",
+    container: { alignItems: "center" },
+    child: { alignSelf: "baseline" },
+  },
+];
+
+function AlignSampleRow({
+  container,
+  child,
+}: {
+  container: ViewStyle;
+  child?: ChildAlign;
+}) {
+  return (
+    <View style={[styles.alignRow, container]}>
+      <Text style={[styles.inlineParaText, child]}>gap py</Text>
+      <RaTeXView
+        latex="y_j"
+        fontSize={INLINE_BASELINE_FONT_SIZE}
+        displayMode={false}
+        color="#111827"
+        style={child}
+      />
+      <Text style={[styles.inlineParaText, child]}>mid</Text>
+      <RaTeXView
+        latex={String.raw`\frac{x^2+1}{x-1}`}
+        fontSize={INLINE_BASELINE_FONT_SIZE}
+        displayMode={false}
+        color="#111827"
+        style={child}
+      />
+      <Text style={[styles.inlineParaText, child]}>end g</Text>
+    </View>
+  );
+}
+
+function CaseYogaAligns() {
+  return (
+    <View style={[styles.card, styles.inlineCard]}>
+      <View style={styles.cardHeader}>
+        <Text style={styles.cardTitle}>Yoga aligns: RaTeXView as flex child</Text>
+      </View>
+      <Text style={styles.smokeHint}>
+        Each row is flexDirection:'row' with the align value below it. The tall
+        fraction gives the row height contrast; 'baseline' (and per-child
+        alignSelf:'baseline') should line the formulas up with the text like
+        glyphs, the rest keep their usual box meaning.
+      </Text>
+      <View style={styles.inlineBody}>
+        {ALIGN_SAMPLES.map((sample) => (
+          <View key={sample.label}>
+            <AlignSampleRow container={sample.container} child={sample.child} />
+            <Text style={styles.alignLabel}>{sample.label}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
 // ─── Case C: Explicit dimensions (control — should always work) ─────
 function CaseExplicit({ renderKey }: { renderKey: number }) {
   const [status, setStatus] = useState<"pending" | "ok" | "error">("pending");
@@ -672,6 +1181,13 @@ export default function App() {
         <CaseLayoutEffectMeasure />
         <CasePR45Smoke />
         <CaseInlineTeXCustomFont />
+        <CaseInlineBaseline />
+        <CaseInlineBaselineNeighbors />
+        <CaseDeepDescenderOverdraw />
+        <CaseInlineAlignOptions />
+        <CaseInlineFontMix />
+        <CaseInlineMaxWidth />
+        <CaseYogaAligns />
 
         <View style={styles.cases}>
           <CaseFlexMinHeight renderKey={key} />
@@ -912,6 +1428,79 @@ const styles = StyleSheet.create({
   smokeFixedHost: {
     alignItems: "center",
     paddingBottom: 8,
+  },
+  inlineCard: {
+    flex: 0,
+    marginHorizontal: 12,
+    marginTop: 8,
+    marginBottom: 8,
+    paddingBottom: 12,
+  },
+  inlineBody: {
+    paddingHorizontal: 12,
+    gap: 12,
+  },
+  inlinePair: {
+    gap: 4,
+  },
+  inlineRow: {
+    borderLeftWidth: 3,
+    paddingLeft: 8,
+    paddingVertical: 2,
+  },
+  inlineRowDefault: {
+    borderLeftColor: "#ef4444",
+  },
+  inlineRowAligned: {
+    borderLeftColor: "#f59e0b",
+  },
+  inlineLegend: {
+    paddingHorizontal: 12,
+    marginBottom: 8,
+    gap: 3,
+  },
+  inlineLegendLine: {
+    fontSize: 11,
+    fontFamily: "Menlo",
+  },
+  inlineRowBaseline: {
+    borderLeftColor: "#3b82f6",
+  },
+  inlineBaseLineText: {
+    alignItems: "baseline",
+  },
+  inlineBaselineRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "baseline",
+    columnGap: 4,
+    rowGap: 2,
+  },
+  alignRow: {
+    flexDirection: "row",
+    columnGap: 6,
+    paddingVertical: 4,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#e5e7eb",
+  },
+  alignLabel: {
+    fontSize: 11,
+    color: "#6b7280",
+    fontFamily: "Menlo",
+    marginTop: 2,
+  },
+  inlineParaText: {
+    fontSize: INLINE_BASELINE_FONT_SIZE,
+    // No lineHeight: RN iOS centers glyphs in a custom lineHeight via a
+    // baselineOffset the attachment placement ignores, sinking every inline
+    // view by (lineHeight - fontLineHeight) / 2 (RN core bug).
+    //
+    // overflow visible: RN <Text> defaults to overflow:'hidden', and on iOS
+    // the paragraph clips its inline-view attachments to its own bounds — a
+    // baseline-aligned formula whose descent exceeds the text descender (e.g.
+    // math bigger than text) would lose its ink below the last line.
+    overflow: "visible",
+    color: "#111827",
   },
   fontCard: {
     flex: 0,

--- a/platforms/react-native/README.md
+++ b/platforms/react-native/README.md
@@ -11,6 +11,8 @@ Native LaTeX math rendering for React Native — no WebView, no JavaScript math 
 - Measures rendered content size for scroll and dynamic layout
 - Error callback for parse failures
 - Bundles all required KaTeX fonts — no extra setup
+- Baseline alignment in flex rows and inside `<Text>` via `alignSelf: 'baseline'`
+- Sync formula metrics (`getTexMetrics`) for custom text engines
 - `InlineTeX` component for mixed text + `$...$` formula strings
 
 ## Requirements
@@ -123,6 +125,24 @@ function Screen() {
 
 If you explicitly provide `style.width` and/or `style.height`, `RaTeXView` will **not** override those values with measurements. Instead, the native view will scale the formula down (never up) to fit the assigned layout size and clip to bounds when necessary.
 
+### Baseline alignment
+
+`RaTeXView` can sit on the text baseline like a glyph — in a flex row and inside `<Text>`:
+
+```tsx
+<View style={{ flexDirection: 'row', alignItems: 'baseline' }}>
+  <Text>f(x) =</Text>
+  <RaTeXView latex={'\\frac{a}{b}'} fontSize={16} displayMode={false} />
+</View>
+
+<Text>
+  compare y with{' '}
+  <RaTeXView latex="y" fontSize={16} displayMode={false}
+             style={{ alignSelf: 'baseline' }} />{' '}
+  mid-sentence
+</Text>
+```
+
 ### `<InlineTeX />`
 
 Renders a mixed string of plain text and `$...$` LaTeX formulas as a single native text flow. Formulas are embedded with `NSTextAttachment` on iOS/macOS and `ReplacementSpan` on Android, so line wrapping, word breaking, and baseline alignment are handled by the platform text layout engine.
@@ -145,6 +165,24 @@ Renders a mixed string of plain text and `$...$` LaTeX formulas as a single nati
 ### `<RaTeXProvider />`
 
 Provides a default formula color to descendant `RaTeXView` and `InlineTeX` components. Use a component-level `color` prop to override the inherited value.
+
+### `getTexMetrics()`
+
+Synchronous formula ink metrics — TeX's box *depth*: what KaTeX emits as `vertical-align: -depth`, MathML Core's *ink line-descent*. For custom text hosts (TextKit / Spannable engines, markdown renderers) that need the baseline offset as a number. Served from the same parse cache as measure/render — an on-screen formula never re-parses.
+
+```tsx
+import { getTexMetrics } from 'ratex-react-native';
+
+// Natural (unscaled) metrics for any formula — no view needed:
+const m = getTexMetrics('\\frac{a}{b}', 16, false);
+// { width, height, depth } | null — dp; the baseline sits at height - depth
+
+// Drawn metrics on a mounted view (fit scale + centering applied):
+const d = ref.current?.getTexMetrics(); // ref: RaTeXViewRef
+// { depth, scale, width, height } | null — apply depth directly
+```
+
+Both are safe to call from `useLayoutEffect`. 
 
 ## Architecture Support
 

--- a/platforms/react-native/README.zh.md
+++ b/platforms/react-native/README.zh.md
@@ -11,6 +11,8 @@ React Native 原生 LaTeX 数学公式渲染库——无 WebView，无 JavaScrip
 - 测量渲染内容尺寸，便于滚动视图和动态布局
 - 提供解析失败的错误回调
 - 内置所有 KaTeX 字体，无需额外配置
+- 通过 `alignSelf: 'baseline'` 在 flex 行和 `<Text>` 内实现基线对齐
+- 同步公式度量 API（`getTexMetrics`），供自定义文本引擎使用
 - `InlineTeX` 组件支持文字与 `$...$` 公式混排
 
 ## 环境要求
@@ -123,6 +125,24 @@ function Screen() {
 
 如果你在 `style` 中显式指定了 `width` 和/或 `height`，`RaTeXView` **不会**再用测量结果覆盖这些值；原生视图会在绘制阶段把公式**按比例缩小（不会放大）**以适配给定布局尺寸，并在必要时按边界裁剪。
 
+### 基线对齐
+
+`RaTeXView` 可以像普通字符一样落在文字基线上——既支持 flex 行，也支持 `<Text>` 内嵌：
+
+```tsx
+<View style={{ flexDirection: 'row', alignItems: 'baseline' }}>
+  <Text>f(x) =</Text>
+  <RaTeXView latex={'\\frac{a}{b}'} fontSize={16} displayMode={false} />
+</View>
+
+<Text>
+  compare y with{' '}
+  <RaTeXView latex="y" fontSize={16} displayMode={false}
+             style={{ alignSelf: 'baseline' }} />{' '}
+  mid-sentence
+</Text>
+```
+
 ### `<InlineTeX />`
 
 将包含 `$...$` 标记的混合字符串渲染为原生内联文本流。公式在 iOS/macOS 上通过 `NSTextAttachment` 嵌入，在 Android 上通过 `ReplacementSpan` 嵌入，因此换行、断词和基线对齐都交给平台文本排版引擎处理。
@@ -145,6 +165,24 @@ function Screen() {
 ### `<RaTeXProvider />`
 
 为后代 `RaTeXView` 和 `InlineTeX` 提供默认公式颜色。若组件自身传入 `color`，则会覆盖继承值。
+
+### `getTexMetrics()`
+
+同步获取公式的墨迹度量——即 TeX 盒模型中的 *depth*：KaTeX 在 Web 端以 `vertical-align: -depth` 输出，MathML Core 中称为 *ink line-descent*。适用于需要以数值形式拿到基线偏移的自定义文本引擎（TextKit / Spannable、markdown 渲染器等）。度量与 measure/render 共享同一解析缓存，屏幕上已有的公式不会重复解析。
+
+```tsx
+import { getTexMetrics } from 'ratex-react-native';
+
+// 任意公式的自然（未缩放）度量——无需挂载视图：
+const m = getTexMetrics('\\frac{a}{b}', 16, false);
+// { width, height, depth } | null —— 单位 dp；基线位于 height - depth 处
+
+// 已挂载视图的实际绘制度量（已应用适配缩放与居中）：
+const d = ref.current?.getTexMetrics(); // ref: RaTeXViewRef
+// { depth, scale, width, height } | null —— depth 可直接使用
+```
+
+两者都可在 `useLayoutEffect` 中安全调用。
 
 ## 架构支持
 

--- a/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/RaTeXViewMeasuringShadowNode.cpp
+++ b/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/RaTeXViewMeasuringShadowNode.cpp
@@ -1,8 +1,51 @@
 #include "RaTeXViewMeasuringShadowNode.h"
 
+#include <fbjni/fbjni.h>
 #include <react/renderer/core/LayoutContext.h>
 
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <optional>
+
 namespace facebook::react {
+
+namespace {
+
+// Natural [widthDp, totalHeightDp, depthDp] from the Kotlin engine
+// (io.ratex.RaTeXMetrics — parse-cache backed, so a formula that has been
+// measured never re-parses). Runs on the Fabric layout thread, the same thread
+// measureContent already calls into Java from, so the app classloader is
+// available to findClassStatic. Returns nullopt on parse failure.
+std::optional<std::array<float, 3>> texMetrics(
+    const RaTeXViewProps& props,
+    Float pointScaleFactor) {
+  static const auto metricsClass =
+      facebook::jni::findClassStatic("io/ratex/RaTeXMetrics");
+  static const auto metricsMethod =
+      metricsClass
+          ->getStaticMethod<jfloatArray(jstring, jfloat, jboolean, jfloat, jint)>(
+              "metrics");
+
+  auto latex = facebook::jni::make_jstring(props.latex);
+  jint colorArgb = props.color ? static_cast<jint>(*props.color)
+                               : static_cast<jint>(0xFF000000);
+  auto result = metricsMethod(
+      metricsClass,
+      latex.get(),
+      static_cast<jfloat>(props.fontSize),
+      static_cast<jboolean>(props.displayMode),
+      static_cast<jfloat>(pointScaleFactor),
+      colorArgb);
+  if (!result) {
+    return std::nullopt;
+  }
+  std::array<float, 3> metrics{};
+  result->getRegion(0, 3, metrics.data());
+  return metrics;
+}
+
+} // namespace
 
 void RaTeXViewMeasuringShadowNode::setMeasurementManager(
     const std::shared_ptr<RaTeXViewMeasurementManager>& measurementsManager) {
@@ -19,6 +62,41 @@ Size RaTeXViewMeasuringShadowNode::measureContent(
   }
   return layoutConstraints.clamp(
       measurementsManager_->measure(getSurfaceId(), layoutConstraints, props));
+}
+
+Float RaTeXViewMeasuringShadowNode::baseline(
+    const LayoutContext& layoutContext,
+    Size size) const {
+  const auto& props = getConcreteProps();
+  // Yoga's default for a node without a real baseline is its bottom edge.
+  const Float fallback = size.height;
+  if (props.latex.empty() || props.fontSize <= 0) {
+    return fallback;
+  }
+  const auto metrics = texMetrics(props, layoutContext.pointScaleFactor);
+  if (!metrics) {
+    return fallback;
+  }
+  const auto naturalWidth = static_cast<Float>((*metrics)[0]);
+  const auto naturalHeight = static_cast<Float>((*metrics)[1]);
+  const auto depth = static_cast<Float>((*metrics)[2]);
+  if (naturalWidth <= 0 || naturalHeight <= 0) {
+    return fallback;
+  }
+  // Mirror RaTeXView.onDraw: scale down (never up) to fit the assigned frame,
+  // center the scaled ink, and put the baseline `depth` above the ink bottom.
+  const Float scale = std::min(
+      Float(1),
+      std::min(size.width / naturalWidth, size.height / naturalHeight));
+  const Float dy = std::max(Float(0), (size.height - naturalHeight * scale) / 2);
+  // Exact drawn ink baseline, snapped to the PIXEL grid (dp flooring made the
+  // raise vary 0..1dp per formula), +1px uniform optical raise (a larger
+  // reported baseline moves the child up). Same rule as iOS and as
+  // RaTeXView.computeInlineShiftPx inside <Text>.
+  const Float pixelScale =
+      layoutContext.pointScaleFactor > 0 ? layoutContext.pointScaleFactor : 1;
+  const Float inkBaseline = dy + naturalHeight * scale - depth * scale;
+  return std::round(inkBaseline * pixelScale) / pixelScale + 1 / pixelScale;
 }
 
 } // namespace facebook::react

--- a/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/RaTeXViewMeasuringShadowNode.h
+++ b/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/RaTeXViewMeasuringShadowNode.h
@@ -18,6 +18,7 @@ class RaTeXViewMeasuringShadowNode final : public RaTeXViewShadowNode {
     auto traits = RaTeXViewShadowNode::BaseTraits();
     traits.set(ShadowNodeTraits::Trait::LeafYogaNode);
     traits.set(ShadowNodeTraits::Trait::MeasurableYogaNode);
+    traits.set(ShadowNodeTraits::Trait::BaselineYogaNode);
     return traits;
   }
 
@@ -27,6 +28,11 @@ class RaTeXViewMeasuringShadowNode final : public RaTeXViewShadowNode {
   Size measureContent(
       const LayoutContext& layoutContext,
       const LayoutConstraints& layoutConstraints) const override;
+
+  /// The drawn formula's alphabetic baseline, so `alignItems: 'baseline'` lines
+  /// the formula up with sibling <Text> exactly like a glyph. Mirrors the view's
+  /// fit-scale/centering draw math against the engine's natural metrics.
+  Float baseline(const LayoutContext& layoutContext, Size size) const override;
 
  private:
   std::shared_ptr<RaTeXViewMeasurementManager> measurementsManager_;

--- a/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/conversions.h
+++ b/platforms/react-native/android/src/main/jni/react/renderer/components/RNRaTeXSpec/conversions.h
@@ -18,6 +18,8 @@ inline folly::dynamic toDynamic(const RaTeXViewProps& props) {
     // On Android, Color is the ARGB int32 — same representation Kotlin uses.
     serializedProps["color"] = *props.color;
   }
+  // "baseline" switches measure to the ascent-only box (see RaTeXViewManager.kt).
+  serializedProps["inlineAlign"] = toString(props.inlineAlign);
   return serializedProps;
 }
 

--- a/platforms/react-native/android/src/main/kotlin/io/ratex/RaTeXMetrics.kt
+++ b/platforms/react-native/android/src/main/kotlin/io/ratex/RaTeXMetrics.kt
@@ -1,0 +1,53 @@
+// RaTeXMetrics.kt — synchronous TeX metrics for native callers (Fabric baseline, TurboModule).
+
+package io.ratex
+
+import android.graphics.Color
+import androidx.annotation.ColorInt
+
+/**
+ * Natural (unscaled) formula metrics, backed by the same parse cache the Fabric
+ * measure pass and [RaTeXView]'s synchronous render use — so a call for a formula
+ * that is already laid out never parses.
+ *
+ * Values are density-independent (dp) and mirror the measure path exactly,
+ * including [RaTeXRenderer.glyphVerticalBleedPx]: the renderer pads the ink box by
+ * one physical pixel top and bottom, so the drawn alphabetic baseline sits at
+ * `heightDp - depthDp` from the view's top ("height" being the total ink height).
+ */
+object RaTeXMetrics {
+
+    /**
+     * Returns `[widthDp, totalHeightDp, depthDp]` for the formula, or null when the
+     * input is empty or fails to parse.
+     *
+     * @param fontSize font size in dp (the RN prop value).
+     * @param density device scale factor — Fabric's `pointScaleFactor` on the C++
+     *   side, `displayMetrics.density` elsewhere. Needed because the renderer's
+     *   anti-alias bleed is one *physical* pixel.
+     * @param colorArgb the view's resolved color: parsing with the same color the
+     *   view renders with shares one parse-cache entry across measure, baseline,
+     *   and the synchronous render.
+     */
+    @JvmStatic
+    fun metrics(
+        latex: String,
+        fontSize: Float,
+        displayMode: Boolean,
+        density: Float,
+        @ColorInt colorArgb: Int = Color.BLACK,
+    ): FloatArray? {
+        if (latex.isBlank() || fontSize <= 0f || density <= 0f) return null
+        return try {
+            val displayList = RaTeXEngine.parseCached(latex, displayMode, colorArgb)
+            val renderer = RaTeXRenderer(displayList, fontSize * density)
+            floatArrayOf(
+                renderer.widthPx / density,
+                renderer.totalHeightPx / density,
+                renderer.depthPx / density,
+            )
+        } catch (_: Throwable) {
+            null
+        }
+    }
+}

--- a/platforms/react-native/android/src/main/kotlin/io/ratex/RaTeXModuleImpl.kt
+++ b/platforms/react-native/android/src/main/kotlin/io/ratex/RaTeXModuleImpl.kt
@@ -1,0 +1,39 @@
+// RaTeXModuleImpl.kt — arch-independent body of the RaTeXModule TurboModule.
+
+package io.ratex
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.WritableMap
+
+/**
+ * Shared body of the new-arch/old-arch RaTeXModule classes. Sync by design
+ * (callers need it in useLayoutEffect); [RaTeXMetrics] is parse-cache-backed.
+ */
+object RaTeXModuleImpl {
+    const val NAME = "RaTeXModule"
+
+    fun getTexMetrics(
+        context: ReactApplicationContext,
+        latex: String,
+        fontSize: Double,
+        displayMode: Boolean,
+        color: Double,
+    ): WritableMap? {
+        val density = context.resources.displayMetrics.density
+        // Render color → one color-keyed cache entry shared with measure/render.
+        val metrics =
+            RaTeXMetrics.metrics(
+                latex,
+                fontSize.toFloat(),
+                displayMode,
+                density,
+                color.toLong().toInt(),
+            ) ?: return null
+        return Arguments.createMap().apply {
+            putDouble("width", metrics[0].toDouble())
+            putDouble("height", metrics[1].toDouble())
+            putDouble("depth", metrics[2].toDouble())
+        }
+    }
+}

--- a/platforms/react-native/android/src/main/kotlin/io/ratex/RaTeXPackage.kt
+++ b/platforms/react-native/android/src/main/kotlin/io/ratex/RaTeXPackage.kt
@@ -2,14 +2,17 @@
 
 package io.ratex
 
-import com.facebook.react.ReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.uimanager.ViewManager
 
-class RaTeXPackage : ReactPackage {
-    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
-        emptyList()
+class RaTeXPackage : BaseReactPackage() {
+    override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? = null
+
+    override fun getReactModuleInfoProvider(): ReactModuleInfoProvider =
+        ReactModuleInfoProvider { emptyMap() }
 
     override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> =
         listOf<ViewManager<*, *>>(

--- a/platforms/react-native/android/src/main/kotlin/io/ratex/RaTeXPackage.kt
+++ b/platforms/react-native/android/src/main/kotlin/io/ratex/RaTeXPackage.kt
@@ -3,16 +3,33 @@
 package io.ratex
 
 import com.facebook.react.BaseReactPackage
+import io.ratex.rn.BuildConfig
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.uimanager.ViewManager
 
 class RaTeXPackage : BaseReactPackage() {
-    override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? = null
+    override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? =
+        when (name) {
+            RaTeXModuleImpl.NAME -> RaTeXModule(reactContext)
+            else -> null
+        }
 
     override fun getReactModuleInfoProvider(): ReactModuleInfoProvider =
-        ReactModuleInfoProvider { emptyMap() }
+        ReactModuleInfoProvider {
+            mapOf(
+                RaTeXModuleImpl.NAME to ReactModuleInfo(
+                    RaTeXModuleImpl.NAME,
+                    RaTeXModule::class.java.name,
+                    false, // canOverrideExistingModule
+                    false, // needsEagerInit
+                    false, // isCxxModule
+                    BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, // isTurboModule
+                ),
+            )
+        }
 
     override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> =
         listOf<ViewManager<*, *>>(

--- a/platforms/react-native/android/src/main/kotlin/io/ratex/RaTeXView.kt
+++ b/platforms/react-native/android/src/main/kotlin/io/ratex/RaTeXView.kt
@@ -11,6 +11,7 @@ import androidx.annotation.ColorInt
 import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.roundToInt
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -85,6 +86,20 @@ class RaTeXView @JvmOverloads constructor(
             rerender()
         }
 
+    /**
+     * Vertical alignment against a host text line that pins the view bottom to the
+     * text baseline (React Native's `<Text>`): "baseline" | "center" | "start" |
+     * "end" | "none". RN sets it from `style.alignSelf`, only under a <Text>
+     * ancestor. Applied via [setTranslationY] — an RN `transform` style would
+     * conflict; don't combine the two on an inline formula.
+     */
+    var inlineAlign: String = "none"
+        set(value) {
+            if (field == value) return
+            field = value
+            applyInlineShift()
+        }
+
     /** Called on the main thread when a render error occurs. */
     var onError: ((RaTeXException) -> Unit)? = null
 
@@ -151,6 +166,22 @@ class RaTeXView @JvmOverloads constructor(
         val contentW = r.widthPx
         val contentH = r.totalHeightPx
 
+        if (inlineAlign == "baseline") {
+            // The frame is the ASCENT-ONLY box (measure reported height − depth):
+            // draw natural-size ink with its baseline on the view bottom, the
+            // descender overflowing below — no clip, height doesn't constrain.
+            val k = if (contentW > 0f) min(1f, availW / contentW) else 1f
+            canvas.save()
+            canvas.translate(
+                paddingLeft.toFloat(),
+                paddingTop + availH - r.heightPx * k,
+            )
+            canvas.scale(k, k)
+            r.draw(canvas)
+            canvas.restore()
+            return
+        }
+
         // Clip to the view bounds so explicit style sizes behave predictably.
         canvas.save()
         canvas.clipRect(0, 0, width, height)
@@ -170,6 +201,27 @@ class RaTeXView @JvmOverloads constructor(
         canvas.scale(scale, scale)
         r.draw(canvas)
         canvas.restore()
+    }
+
+    /**
+     * The drawn formula's alphabetic baseline, for baseline-aligning native layouts
+     * (LinearLayout etc.). Mirrors [onDraw]'s fit-scale/centering math so the
+     * reported baseline always matches the ink actually painted.
+     */
+    override fun getBaseline(): Int {
+        val r = renderer ?: return -1
+        val availW = (width - paddingLeft - paddingRight).toFloat().coerceAtLeast(0f)
+        val availH = (height - paddingTop - paddingBottom).toFloat().coerceAtLeast(0f)
+        val contentW = r.widthPx
+        val contentH = r.totalHeightPx
+        if (contentW <= 0f || contentH <= 0f) return -1
+        if (inlineAlign == "baseline") {
+            // Ascent-only frame: the drawn ink baseline sits on the view bottom.
+            return (paddingTop + availH).roundToInt()
+        }
+        val scale = min(1f, min(availW / contentW, availH / contentH))
+        val dy = paddingTop + ((availH - contentH * scale) / 2f).coerceAtLeast(0f)
+        return (dy + r.heightPx * scale).roundToInt()
     }
 
     // MARK: - Lifecycle
@@ -192,6 +244,52 @@ class RaTeXView @JvmOverloads constructor(
         if (renderer == null && latex.isNotBlank() && renderJob?.isActive != true) rerender()
     }
 
+    /**
+     * See [inlineAlign]: downward translation (px) of the view against the host
+     * text's bottom-on-baseline placement. Mirrors [onDraw]'s fit-scale (`k`) +
+     * centering gap (`g`) so a clamped/scaled box still anchors correctly.
+     */
+    private fun applyInlineShift() {
+        translationY = computeInlineShiftPx()
+    }
+
+    private fun computeInlineShiftPx(): Float {
+        if (inlineAlign == "none") return 0f
+        val r = renderer ?: return 0f
+        val contentW = r.widthPx
+        val contentH = r.totalHeightPx
+        if (contentW <= 0f || contentH <= 0f) return 0f
+        val density = context.resources.displayMetrics.density
+        val availW = (width - paddingLeft - paddingRight).toFloat().coerceAtLeast(0f)
+        val availH = (height - paddingTop - paddingBottom).toFloat().coerceAtLeast(0f)
+        var k = 1f
+        var g = 0f
+        if (availW > 0f && availH > 0f) {
+            k = min(1f, min(availW / contentW, availH / contentH))
+            g = ((availH - contentH * k) / 2f).coerceAtLeast(0f)
+        }
+        val inkHeightPx = contentH * k
+        val shiftPx = when (inlineAlign) {
+            // "baseline" needs no translate: measure reports the ascent-only box
+            // and onDraw bottom-anchors the ink — only the optical raise remains.
+            // center/start/end use em fractions assuming host text at [fontSize]
+            // (math axis 0.25em, line box 0.75/0.25em).
+            "baseline" -> 0f
+            "center" -> g + inkHeightPx / 2f - 0.25f * fontSize * density
+            "start" -> g + inkHeightPx - 0.75f * fontSize * density
+            "end" -> g + 0.25f * fontSize * density
+            else -> return 0f
+        }
+        // Pixel-snap, then the same 1px optical raise as the shadow baseline().
+        return shiftPx.roundToInt() - 1f
+    }
+
+    /** The inline shift depends on the laid-out size (fit-scale, centering gap). */
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        applyInlineShift()
+    }
+
     // MARK: - Private
 
     private fun rerender() {
@@ -199,6 +297,7 @@ class RaTeXView @JvmOverloads constructor(
         renderJob = null
         if (latex.isBlank()) {
             renderer = null
+            applyInlineShift()
             requestSelfLayout()
             invalidate()
             return
@@ -260,6 +359,7 @@ class RaTeXView @JvmOverloads constructor(
         val density = context.resources.displayMetrics.density
         val r = RaTeXRenderer(dl, fontSize * density) { RaTeXFontLoader.getTypeface(it) }
         renderer = r
+        applyInlineShift()
         requestSelfLayout()
         invalidate()
         val widthDp = r.widthPx / density

--- a/platforms/react-native/android/src/newarch/kotlin/io/ratex/RaTeXModule.kt
+++ b/platforms/react-native/android/src/newarch/kotlin/io/ratex/RaTeXModule.kt
@@ -1,0 +1,20 @@
+// RaTeXModule.kt (New Architecture) — TurboModule over the codegen spec.
+
+package io.ratex
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.module.annotations.ReactModule
+
+@ReactModule(name = RaTeXModuleImpl.NAME)
+class RaTeXModule(reactContext: ReactApplicationContext) :
+    NativeRaTeXModuleSpec(reactContext) {
+
+    override fun getTexMetrics(
+        latex: String,
+        fontSize: Double,
+        displayMode: Boolean,
+        color: Double,
+    ): WritableMap? =
+        RaTeXModuleImpl.getTexMetrics(reactApplicationContext, latex, fontSize, displayMode, color)
+}

--- a/platforms/react-native/android/src/newarch/kotlin/io/ratex/RaTeXViewManager.kt
+++ b/platforms/react-native/android/src/newarch/kotlin/io/ratex/RaTeXViewManager.kt
@@ -69,6 +69,11 @@ class RaTeXViewManager(private val reactContext: ReactApplicationContext) :
         view.displayMode = value
     }
 
+    @ReactProp(name = "inlineAlign")
+    override fun setInlineAlign(view: RaTeXView, value: String?) {
+        view.inlineAlign = value ?: "none"
+    }
+
     @ReactProp(name = "color", customType = "Color")
     override fun setColor(view: RaTeXView, value: Int?) {
         view.color = value ?: Color.BLACK
@@ -107,7 +112,16 @@ class RaTeXViewManager(private val reactContext: ReactApplicationContext) :
             val density = context.resources.displayMetrics.density
             val displayList = RaTeXEngine.parseCached(latex, displayMode, color)
             val renderer = RaTeXRenderer(displayList, fontSize * density)
-            YogaMeasureOutput.make(renderer.widthPx / density, renderer.totalHeightPx / density)
+            // Inside <Text> (inlineAlign is only ever set there) the text engine
+            // reserves the whole height as line ascent — report the ascent-only
+            // box; the view draws natural-size ink bottom-anchored (RaTeXView).
+            val heightPx =
+                if (props?.getString("inlineAlign") == "baseline") {
+                    renderer.heightPx // ascent only — ink baseline to ink top
+                } else {
+                    renderer.totalHeightPx
+                }
+            YogaMeasureOutput.make(renderer.widthPx / density, heightPx / density)
         } catch (e: Throwable) {
             YogaMeasureOutput.make(0f, 0f)
         }

--- a/platforms/react-native/android/src/oldarch/kotlin/io/ratex/RaTeXModule.kt
+++ b/platforms/react-native/android/src/oldarch/kotlin/io/ratex/RaTeXModule.kt
@@ -1,0 +1,26 @@
+// RaTeXModule.kt (Old Architecture) — bridge module with a blocking sync method,
+// mirroring the codegen-generated spec the new-arch class extends.
+
+package io.ratex
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.module.annotations.ReactModule
+
+@ReactModule(name = RaTeXModuleImpl.NAME)
+class RaTeXModule(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext) {
+
+    override fun getName(): String = RaTeXModuleImpl.NAME
+
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    fun getTexMetrics(
+        latex: String,
+        fontSize: Double,
+        displayMode: Boolean,
+        color: Double,
+    ): WritableMap? =
+        RaTeXModuleImpl.getTexMetrics(reactApplicationContext, latex, fontSize, displayMode, color)
+}

--- a/platforms/react-native/android/src/oldarch/kotlin/io/ratex/RaTeXViewManager.kt
+++ b/platforms/react-native/android/src/oldarch/kotlin/io/ratex/RaTeXViewManager.kt
@@ -54,6 +54,11 @@ class RaTeXViewManager(private val reactContext: ReactApplicationContext) :
         view.displayMode = value
     }
 
+    @ReactProp(name = "inlineAlign")
+    fun setInlineAlign(view: RaTeXView, value: String?) {
+        view.inlineAlign = value ?: "none"
+    }
+
     @ReactProp(name = "color", customType = "Color")
     fun setColor(view: RaTeXView, value: Int?) {
         view.color = value ?: Color.BLACK

--- a/platforms/react-native/ios/RaTeXModule.mm
+++ b/platforms/react-native/ios/RaTeXModule.mm
@@ -1,0 +1,81 @@
+// RaTeXModule.mm — sync TeX metrics for JS (old & new arch). Sync by design
+// (callers need it in useLayoutEffect); backed by RaTeXMeasure's parse cache.
+
+#import <React/RCTBridgeModule.h>
+
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <RNRaTeXSpec/RNRaTeXSpec.h>
+#endif
+
+// Swift-generated header — same framework/static-library dance as RaTeXViewManager.mm.
+#if __has_include(<ratex_react_native/ratex_react_native-Swift.h>)
+#import <ratex_react_native/ratex_react_native-Swift.h>
+#else
+#import "ratex_react_native-Swift.h"
+#endif
+
+@interface RaTeXModule : NSObject <RCTBridgeModule
+#ifdef RCT_NEW_ARCH_ENABLED
+                                   ,
+                                   NativeRaTeXModuleSpec
+#endif
+                                   >
+@end
+
+@implementation RaTeXModule
+
+RCT_EXPORT_MODULE(RaTeXModule)
+
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
+- (NSDictionary *_Nullable)texMetricsForLatex:(NSString *)latex
+                                     fontSize:(double)fontSize
+                                  displayMode:(BOOL)displayMode
+{
+  RaTeXTexMetrics *metrics = [RaTeXMeasure metricsLatex:latex
+                                                fontSize:(CGFloat)fontSize
+                                             displayMode:displayMode];
+  if (metrics == nil) {
+    return nil;
+  }
+  return @{
+    @"width" : @(metrics.width),
+    @"height" : @(metrics.height),
+    @"depth" : @(metrics.depth),
+  };
+}
+
+#ifdef RCT_NEW_ARCH_ENABLED
+
+// `color` exists for Android's color-keyed cache; iOS metrics are color-blind.
+- (NSDictionary *_Nullable)getTexMetrics:(NSString *)latex
+                                fontSize:(double)fontSize
+                             displayMode:(BOOL)displayMode
+                                   color:(double)color
+{
+  return [self texMetricsForLatex:latex fontSize:fontSize displayMode:displayMode];
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return std::make_shared<facebook::react::NativeRaTeXModuleSpecJSI>(params);
+}
+
+#else // !RCT_NEW_ARCH_ENABLED
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getTexMetrics
+                                       : (NSString *)latex fontSize
+                                       : (double)fontSize displayMode
+                                       : (BOOL)displayMode color
+                                       : (double)color)
+{
+  return [self texMetricsForLatex:latex fontSize:fontSize displayMode:displayMode];
+}
+
+#endif // RCT_NEW_ARCH_ENABLED
+
+@end

--- a/platforms/react-native/ios/RaTeXRNView.swift
+++ b/platforms/react-native/ios/RaTeXRNView.swift
@@ -16,6 +16,8 @@ public class RaTeXRNView: PlatformView {
 
     private let innerView = RaTeXView()
     private var bridgedColor: PlatformColor?
+    private var innerTopConstraint: NSLayoutConstraint?
+    private var innerBottomConstraint: NSLayoutConstraint?
 
     // MARK: - ObjC-bridgeable properties
 
@@ -52,6 +54,164 @@ public class RaTeXRNView: PlatformView {
             platformSetNeedsLayout()
         }
     }
+
+    /// Vertical alignment inside a host `<Text>` (which pins the view bottom to
+    /// the text baseline and ignores alignSelf). Set by RaTeXView.tsx from
+    /// `style.alignSelf`, and only under a <Text> ancestor — in a flex row Yoga
+    /// aligns via the shadow node's baseline() and this stays "none".
+    @objc public var inlineAlign: String = "none" {
+        didSet {
+            guard inlineAlign != oldValue else { return }
+            platformSetNeedsLayout()
+        }
+    }
+
+    #if !os(macOS)
+    /// Stock RN bug: the NSTextAttachment run has no font attribute, so
+    /// RCTTextLayoutManager's placement uses the 12pt default font's descender
+    /// and every inline view sinks `hostDescent − |systemFont(12).descender|`
+    /// below the baseline. Reconstruct that error from the hosting paragraph's
+    /// `attributedText` (public introspection API): our run's font (nil on
+    /// stock RN) vs the nearest neighboring run's font (the line's real font).
+    /// On a fixed RN the run carries the real font and this returns ~0.
+    private func stockAttachmentSink() -> CGFloat {
+        let defaultRunDescent = -UIFont.systemFont(ofSize: 12).descender
+        // Fallback: assume host text is system font at our size.
+        let contractSink =
+            -UIFont.systemFont(ofSize: innerView.fontSize).descender - defaultRunDescent
+        var child: UIView = self
+        var paragraph: UIView?
+        while let parent = child.superview {
+            if NSStringFromClass(type(of: parent)).contains("ParagraphComponentView") {
+                paragraph = parent
+                break
+            }
+            child = parent
+        }
+        guard let paragraph, paragraph.responds(to: NSSelectorFromString("attributedText")),
+            let text = paragraph.value(forKey: "attributedText") as? NSAttributedString,
+            text.length > 0
+        else { return contractSink }
+        // Our run = k-th attachment, k = our ordinal among the paragraph's
+        // (attachment-only) subviews.
+        let ordinal = paragraph.subviews.firstIndex(of: child) ?? 0
+        var runRange = NSRange(location: NSNotFound, length: 0)
+        var runFont: UIFont?
+        var seen = 0
+        text.enumerateAttribute(
+            .attachment, in: NSRange(location: 0, length: text.length)
+        ) { value, range, stop in
+            guard value is NSTextAttachment else { return }
+            if seen == ordinal {
+                runRange = range
+                runFont = text.attribute(.font, at: range.location, effectiveRange: nil) as? UIFont
+                stop.pointee = true
+            }
+            seen += 1
+        }
+        guard runRange.location != NSNotFound else { return contractSink }
+        // Nearest run with a font (skips adjacent font-less attachment runs).
+        var hostFont: UIFont?
+        var i = runRange.location - 1
+        while i >= 0 {
+            var eff = NSRange()
+            if let f = text.attribute(.font, at: i, effectiveRange: &eff) as? UIFont {
+                hostFont = f
+                break
+            }
+            i = eff.location - 1
+        }
+        if hostFont == nil {
+            var j = NSMaxRange(runRange)
+            while j < text.length {
+                var eff = NSRange()
+                if let f = text.attribute(.font, at: j, effectiveRange: &eff) as? UIFont {
+                    hostFont = f
+                    break
+                }
+                j = NSMaxRange(eff)
+            }
+        }
+        guard let hostFont else { return contractSink }
+        return -hostFont.descender - (runFont.map { -$0.descender } ?? defaultRunDescent)
+    }
+    #endif
+
+    /// Inner-view offsets against the host text's bottom-on-baseline placement,
+    /// in points, pixel-snapped. "baseline": the wrapper is the ASCENT-ONLY box
+    /// (the shadow node measures height − depth), so the natural-size inner view
+    /// anchors its ink baseline to the wrapper bottom and its descender overflows
+    /// below (top ≠ bottom constant — the inner is taller than the wrapper).
+    /// center/start/end keep the full-height wrapper and a pure translate,
+    /// assuming host text at our fontSize (math axis 0.25em, line box
+    /// 0.75/0.25em em fractions).
+    private var inlineOffsets: (top: CGFloat, bottom: CGFloat) {
+        guard inlineAlign != "none",
+            bounds.width > 0, bounds.height > 0,
+            let metrics = RaTeXMeasure.metricsLatex(
+                innerView.latex, fontSize: innerView.fontSize, displayMode: innerView.displayMode),
+            metrics.width > 0, metrics.height > 0
+        else { return (0, 0) }
+        #if os(macOS)
+        let scale = window?.backingScaleFactor ?? 2
+        let sink: CGFloat = 0
+        #else
+        let sink = stockAttachmentSink()
+        let scale = window?.screen.scale ?? UIScreen.main.scale
+        #endif
+        if inlineAlign == "baseline" {
+            // Height no longer constrains the fit — it was derived from the ink.
+            let k = min(1, bounds.width / metrics.width)
+            var top = bounds.height - (metrics.height - metrics.depth) * k - sink
+            // −2 physical px, measured: −1 residual TextKit sub-pixel bias
+            // (always low, never high), −1 optical raise matching baseline().
+            top = (top * scale).rounded() / scale - 2 / scale
+            // Inner keeps its natural (scaled) height; descender overflows below.
+            let bottom = top + metrics.height * k - bounds.height
+            return (top, bottom)
+        }
+        let k = min(1, min(bounds.width / metrics.width, bounds.height / metrics.height))
+        let g = max(0, (bounds.height - metrics.height * k) / 2)
+        let inkHeight = metrics.height * k
+        let em = innerView.fontSize
+        var shift: CGFloat
+        switch inlineAlign {
+        case "center":
+            shift = g + inkHeight / 2 - 0.25 * em
+        case "start":
+            shift = g + inkHeight - 0.75 * em
+        case "end":
+            shift = g + 0.25 * em
+        default:
+            return (0, 0)
+        }
+        shift = ((shift - sink) * scale).rounded() / scale - 2 / scale
+        return (shift, shift)
+    }
+
+    private func updateInlineShift() {
+        let offsets = inlineOffsets
+        // Runs from the layout pass — the guard prevents a re-layout loop.
+        guard innerTopConstraint?.constant != offsets.top
+            || innerBottomConstraint?.constant != offsets.bottom
+        else { return }
+        innerTopConstraint?.constant = offsets.top
+        innerBottomConstraint?.constant = offsets.bottom
+        platformSetNeedsLayout()
+    }
+
+    // The pixel scale is only a guess until the view joins a window.
+    #if os(macOS)
+    public override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        platformSetNeedsLayout()
+    }
+    #else
+    public override func didMoveToWindow() {
+        super.didMoveToWindow()
+        platformSetNeedsLayout()
+    }
+    #endif
 
     @objc public var color: PlatformColor? {
         get { bridgedColor }
@@ -154,6 +314,9 @@ public class RaTeXRNView: PlatformView {
     #endif
 
     private func performLayoutReporting() {
+        // The shift depends on the laid-out bounds — re-resolve every pass.
+        updateInlineShift()
+        updateBaselineGuide()
         let size = innerView.intrinsicContentSize
         guard size.width > 0, size.height > 0 else { return }
         guard size != lastReportedContentSize else { return }
@@ -161,6 +324,47 @@ public class RaTeXRNView: PlatformView {
         contentSizeCallback?(size.width, size.height)
         onContentSizeChange?(["width": size.width, "height": size.height])
     }
+
+    // MARK: - Baseline (native AutoLayout)
+
+    #if os(macOS)
+    public override var firstBaselineOffsetFromTop: CGFloat {
+        innerView.frame.origin.y + (innerView.baselineFromTop ?? bounds.height)
+    }
+
+    public override var baselineOffsetFromBottom: CGFloat {
+        bounds.height - firstBaselineOffsetFromTop
+    }
+
+    private func updateBaselineGuide() {}
+    #else
+    /// Zero-size guide whose bottom edge tracks the drawn formula's alphabetic
+    /// baseline, so `firstBaselineAnchor` / `lastBaselineAnchor` constraints align
+    /// the formula with neighboring text.
+    private let baselineGuide: UIView = {
+        let guide = UIView()
+        guide.isHidden = true
+        guide.isUserInteractionEnabled = false
+        return guide
+    }()
+
+    public override var forFirstBaselineLayout: UIView {
+        updateBaselineGuide()
+        return baselineGuide
+    }
+
+    public override var forLastBaselineLayout: UIView {
+        updateBaselineGuide()
+        return baselineGuide
+    }
+
+    private func updateBaselineGuide() {
+        guard baselineGuide.superview === self else { return }
+        let baseline =
+            innerView.frame.origin.y + (innerView.baselineFromTop ?? bounds.height)
+        baselineGuide.frame = CGRect(x: 0, y: 0, width: bounds.width, height: baseline)
+    }
+    #endif
 
     // MARK: - Private
 
@@ -182,14 +386,23 @@ public class RaTeXRNView: PlatformView {
         layer?.backgroundColor = NSColor.clear.cgColor
         #else
         backgroundColor = .clear
+        addSubview(baselineGuide)
         #endif
         addSubview(innerView)
         innerView.translatesAutoresizingMaskIntoConstraints = false
+        // Top/bottom constants position the inner view: equal constants = pure
+        // translate (center/start/end); baseline mode sets them apart so the
+        // inner keeps natural height and its descender overflows the
+        // ascent-only wrapper (clipsToBounds stays false).
+        let top = innerView.topAnchor.constraint(equalTo: topAnchor)
+        let bottom = innerView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        innerTopConstraint = top
+        innerBottomConstraint = bottom
         NSLayoutConstraint.activate([
             innerView.leadingAnchor.constraint(equalTo: leadingAnchor),
             innerView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            innerView.topAnchor.constraint(equalTo: topAnchor),
-            innerView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            top,
+            bottom,
         ])
         // Load fonts from the CocoaPods resource bundle (not the main bundle or SPM bundle).
         // Guard ensures we only do this once across all RaTeXRNView instances.
@@ -200,23 +413,74 @@ public class RaTeXRNView: PlatformView {
     }
 }
 
+/// Natural (unscaled) formula metrics in points at a given font size.
+/// `height` is the total ink height; the alphabetic baseline sits at
+/// `height - depth` from the top of the ink box.
+@objc(RaTeXTexMetrics)
+public final class RaTeXTexMetrics: NSObject {
+    @objc public let width: CGFloat
+    @objc public let height: CGFloat
+    @objc public let depth: CGFloat
+
+    init(width: CGFloat, height: CGFloat, depth: CGFloat) {
+        self.width = width
+        self.height = height
+        self.depth = depth
+    }
+}
+
 /// Thread-safe synchronous LaTeX measurement.
 ///
-/// Used by the Fabric shadow node's `measureContent` so the component self-sizes
-/// during Yoga layout — making its size available at `useLayoutEffect` instead of
-/// only after the async `onContentSizeChange` event. Safe to call off the main
-/// thread: `RaTeXEngine.parse` is thread-safe (thread-local FFI error state) and
-/// `RaTeXRenderer` is a value type; fonts are not needed for measurement.
+/// Used by the Fabric shadow node's `measureContent` (self-sizing during Yoga
+/// layout) and `baseline` (alignItems:'baseline'), which run per layout pass —
+/// so parses are cached, keyed by (latex, displayMode). The DisplayList is in em
+/// units: fontSize is applied afterwards and color never affects metrics. Safe to
+/// call off the main thread: `RaTeXEngine.parse` is thread-safe (thread-local FFI
+/// error state) and `RaTeXRenderer` is a value type; fonts are not needed for
+/// measurement.
 @objc(RaTeXMeasure)
 public final class RaTeXMeasure: NSObject {
-    @objc public static func measureLatex(_ latex: String, fontSize: CGFloat, displayMode: Bool) -> CGSize {
-        guard !latex.isEmpty, fontSize > 0 else { return .zero }
-        do {
-            let displayList = try RaTeXEngine.shared.parse(latex, displayMode: displayMode, color: .black)
-            let renderer = RaTeXRenderer(displayList: displayList, fontSize: fontSize)
-            return CGSize(width: renderer.width, height: renderer.totalHeight)
-        } catch {
-            return .zero
+    private static let cacheLock = NSLock()
+    private static var cache: [String: DisplayList] = [:]
+    private static var cacheOrder: [String] = []
+    private static let cacheMaxEntries = 128
+
+    private static func parseCached(_ latex: String, displayMode: Bool) -> DisplayList? {
+        let key = (displayMode ? "D|" : "T|") + latex
+        cacheLock.lock()
+        if let hit = cache[key] {
+            cacheLock.unlock()
+            return hit
         }
+        cacheLock.unlock()
+        // Parse outside the lock so a slow parse never blocks other lookups; racing
+        // duplicate parses of the same key produce identical output (last put wins).
+        guard let parsed = try? RaTeXEngine.shared.parse(latex, displayMode: displayMode, color: .black) else {
+            return nil
+        }
+        cacheLock.lock()
+        if cache[key] == nil {
+            cache[key] = parsed
+            cacheOrder.append(key)
+            if cacheOrder.count > cacheMaxEntries {
+                cache.removeValue(forKey: cacheOrder.removeFirst())
+            }
+        }
+        cacheLock.unlock()
+        return parsed
+    }
+
+    @objc public static func measureLatex(_ latex: String, fontSize: CGFloat, displayMode: Bool) -> CGSize {
+        guard let m = metricsLatex(latex, fontSize: fontSize, displayMode: displayMode) else { return .zero }
+        return CGSize(width: m.width, height: m.height)
+    }
+
+    /// Natural width / total height / depth in points, or nil when the input is
+    /// empty or fails to parse.
+    @objc public static func metricsLatex(_ latex: String, fontSize: CGFloat, displayMode: Bool) -> RaTeXTexMetrics? {
+        guard !latex.isEmpty, fontSize > 0 else { return nil }
+        guard let displayList = parseCached(latex, displayMode: displayMode) else { return nil }
+        let renderer = RaTeXRenderer(displayList: displayList, fontSize: fontSize)
+        return RaTeXTexMetrics(width: renderer.width, height: renderer.totalHeight, depth: renderer.depth)
     }
 }

--- a/platforms/react-native/ios/RaTeXView.swift
+++ b/platforms/react-native/ios/RaTeXView.swift
@@ -96,6 +96,21 @@ public class RaTeXView: PlatformView {
         return CGSize(width: r.width, height: r.totalHeight)
     }
 
+    /// Distance from the view's top to the drawn formula's alphabetic baseline, or
+    /// nil before anything has rendered. Mirrors `draw(_:)`'s fit-scale/centering
+    /// math so the reported baseline always matches the ink actually painted.
+    public var baselineFromTop: CGFloat? {
+        guard let r = renderer else { return nil }
+        let contentW = r.width
+        let contentH = r.totalHeight
+        guard contentW > 0, contentH > 0 else { return nil }
+        let sx = bounds.width / contentW
+        let sy = bounds.height / contentH
+        let scale = min(1, min(sx, sy))
+        let dy = max(0, (bounds.height - contentH * scale) / 2)
+        return dy + r.height * scale
+    }
+
     // MARK: Drawing
 
     public override func draw(_ rect: CGRect) {

--- a/platforms/react-native/ios/RaTeXViewManager.mm
+++ b/platforms/react-native/ios/RaTeXViewManager.mm
@@ -10,6 +10,7 @@
 #import <react/renderer/components/RNRaTeXSpec/RCTComponentViewHelpers.h>
 #import <react/renderer/core/LayoutConstraints.h>
 #import <react/renderer/core/LayoutContext.h>
+#include <algorithm>
 #include <cmath>
 #else
 #import "RaTeXViewManager.h"
@@ -64,6 +65,7 @@ class RaTeXViewMeasuringShadowNode final : public RaTeXViewShadowNode {
     auto traits = RaTeXViewShadowNode::BaseTraits();
     traits.set(ShadowNodeTraits::Trait::LeafYogaNode);
     traits.set(ShadowNodeTraits::Trait::MeasurableYogaNode);
+    traits.set(ShadowNodeTraits::Trait::BaselineYogaNode);
     return traits;
   }
 
@@ -77,16 +79,67 @@ class RaTeXViewMeasuringShadowNode final : public RaTeXViewShadowNode {
     if (latex == nil) {
       return layoutConstraints.clamp(facebook::react::Size{0, 0});
     }
-    CGSize measured = [RaTeXMeasure measureLatex:latex
-                                        fontSize:static_cast<CGFloat>(props.fontSize)
-                                     displayMode:props.displayMode ? YES : NO];
+    RaTeXTexMetrics *metrics = [RaTeXMeasure metricsLatex:latex
+                                                 fontSize:static_cast<CGFloat>(props.fontSize)
+                                              displayMode:props.displayMode ? YES : NO];
+    if (metrics == nil) {
+      return layoutConstraints.clamp(facebook::react::Size{0, 0});
+    }
+    Float measuredHeight = static_cast<Float>(metrics.height);
+    // Inside <Text> (inlineAlign is only ever set there) the text engine pins the
+    // view bottom to the baseline and reserves the whole height as line ASCENT.
+    // Report the ascent-only box (height − depth) so the line above gets the same
+    // spacing a baseline-aligned flex row produces; the view draws its natural-size
+    // ink anchored to the bottom, descender overflowing (RaTeXRNView).
+    if (props.inlineAlign == RaTeXViewInlineAlign::Baseline) {
+      measuredHeight -= static_cast<Float>(metrics.depth);
+    }
     // Snap up to the pixel grid so Yoga's position-dependent edge rounding can't vary the
     // reported height across placements of the same formula. Uses Yoga's own scale factor.
     Float scale = layoutContext.pointScaleFactor > 0 ? layoutContext.pointScaleFactor : 1;
-    Float width = std::ceil(static_cast<Float>(measured.width) * scale) / scale;
-    Float height = std::ceil(static_cast<Float>(measured.height) * scale) / scale;
+    Float width = std::ceil(static_cast<Float>(metrics.width) * scale) / scale;
+    Float height = std::ceil(measuredHeight * scale) / scale;
     facebook::react::Size size{width, height};
     return layoutConstraints.clamp(size);
+  }
+
+  // The drawn formula's alphabetic baseline, so `alignItems: 'baseline'` lines the
+  // formula up with sibling <Text> exactly like a glyph. Mirrors the view's
+  // fit-scale/centering draw math against the engine's natural metrics.
+  Float baseline(const LayoutContext &layoutContext, facebook::react::Size size) const override {
+    const auto &props = getConcreteProps();
+    // Yoga's default for a node without a real baseline is its bottom edge.
+    const Float fallback = size.height;
+    if (props.latex.empty() || props.fontSize <= 0) {
+      return fallback;
+    }
+    NSString *latex = [NSString stringWithUTF8String:props.latex.c_str()];
+    if (latex == nil) {
+      return fallback;
+    }
+    RaTeXTexMetrics *metrics = [RaTeXMeasure metricsLatex:latex
+                                                 fontSize:static_cast<CGFloat>(props.fontSize)
+                                              displayMode:props.displayMode ? YES : NO];
+    if (metrics == nil) {
+      return fallback;
+    }
+    const Float naturalWidth = static_cast<Float>(metrics.width);
+    const Float naturalHeight = static_cast<Float>(metrics.height);
+    const Float depth = static_cast<Float>(metrics.depth);
+    if (naturalWidth <= 0 || naturalHeight <= 0) {
+      return fallback;
+    }
+    const Float scale = std::min(
+        Float(1), std::min(size.width / naturalWidth, size.height / naturalHeight));
+    const Float dy = std::max(Float(0), (size.height - naturalHeight * scale) / 2);
+    // Exact drawn ink baseline, snapped to the PIXEL grid (whole-point flooring
+    // made the raise vary 0..1pt per formula), +1px uniform optical raise
+    // (a larger reported baseline moves the child up). RaTeXRNView.inlineShift
+    // applies the same rule inside <Text>.
+    const Float pixelScale =
+        layoutContext.pointScaleFactor > 0 ? layoutContext.pointScaleFactor : 1;
+    const Float inkBaseline = dy + naturalHeight * scale - depth * scale;
+    return std::round(inkBaseline * pixelScale) / pixelScale + 1 / pixelScale;
   }
 };
 
@@ -172,6 +225,15 @@ using RaTeXViewMeasuringComponentDescriptor =
     _nativeView.displayMode = displayMode;
   }
 
+  // Derived from style.alignSelf by RaTeXView.tsx; drives the native in-<Text>
+  // vertical alignment shift (see RaTeXRNView.inlineAlign — applied only when
+  // the view detects a text host, so flex-sibling alignment stays pure Yoga).
+  NSString *inlineAlign =
+      [NSString stringWithUTF8String:toString(newProps.inlineAlign).c_str()];
+  if (![inlineAlign isEqualToString:_nativeView.inlineAlign]) {
+    _nativeView.inlineAlign = inlineAlign;
+  }
+
 #if TARGET_OS_OSX
   NSColor *color = RaTeXPlatformColorFromSharedColor(newProps.color);
 #else
@@ -225,6 +287,7 @@ RCT_EXPORT_MODULE(RaTeXView)
 RCT_EXPORT_VIEW_PROPERTY(latex, NSString)
 RCT_EXPORT_VIEW_PROPERTY(fontSize, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(displayMode, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(inlineAlign, NSString)
 #if TARGET_OS_OSX
 RCT_EXPORT_VIEW_PROPERTY(color, NSColor)
 #else

--- a/platforms/react-native/package.json
+++ b/platforms/react-native/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/erweixin/RaTeX",
   "codegenConfig": {
     "name": "RNRaTeXSpec",
-    "type": "components",
+    "type": "all",
     "jsSrcsDir": "src",
     "ios": {
       "componentProvider": {

--- a/platforms/react-native/src/NativeRaTeXModule.ts
+++ b/platforms/react-native/src/NativeRaTeXModule.ts
@@ -1,0 +1,29 @@
+import type {TurboModule} from 'react-native';
+import {TurboModuleRegistry} from 'react-native';
+
+/** Natural (unscaled) formula metrics in dp at the given font size. */
+export type NativeTexMetrics = {
+  /** Ink width. */
+  width: number;
+  /** Total ink height (ascent + depth). */
+  height: number;
+  /** Descent below the alphabetic baseline; the baseline sits at height - depth from the top. */
+  depth: number;
+};
+
+export interface Spec extends TurboModule {
+  /**
+   * Sync TeX metrics, backed by the parse cache the native measure/render
+   * passes share — an on-screen formula never re-parses. Null when empty or
+   * parse failed. Sync on purpose: callers need it inside useLayoutEffect.
+   */
+  getTexMetrics(
+    latex: string,
+    fontSize: number,
+    displayMode: boolean,
+    /** Processed ARGB view color — Android's cache is color-keyed; iOS ignores it. */
+    color: number,
+  ): NativeTexMetrics | null;
+}
+
+export default TurboModuleRegistry.get<Spec>('RaTeXModule');

--- a/platforms/react-native/src/RaTeXView.tsx
+++ b/platforms/react-native/src/RaTeXView.tsx
@@ -5,9 +5,25 @@ import React, {
   useEffect,
   useState,
 } from 'react';
+import * as ReactNative from 'react-native';
 import {StyleSheet} from 'react-native';
 import type {ColorValue, StyleProp, ViewStyle} from 'react-native';
 import RaTeXViewNativeComponent from './RaTeXViewNativeComponent';
+
+// True inside <Text> (reset by nested <View>) — "am I an inline attachment".
+// Native code can't tell: Android Fabric hoists inline views into the text's
+// parent ViewGroup. Legacy module path covers RN without the unstable export.
+const TextAncestorContext: React.Context<boolean> =
+  (
+    ReactNative as unknown as {
+      unstable_TextAncestorContext?: React.Context<boolean>;
+    }
+  ).unstable_TextAncestorContext ??
+  (
+    require('react-native/Libraries/Text/TextAncestor') as {
+      default: React.Context<boolean>;
+    }
+  ).default;
 
 export const RaTeXColorContext = createContext<ColorValue | undefined>(undefined);
 
@@ -46,18 +62,25 @@ export interface RaTeXViewProps {
   }) => void;
 }
 
-// On the new architecture (Fabric) the native component self-sizes synchronously
-// during layout via the shadow node's measureContent, so feeding the async
-// onContentSizeChange measurement back as an explicit width/height style is
-// redundant — and actively harmful: the event carries the UNCONSTRAINED content
-// size, so re-applying it as an explicit style overrides whatever clamp the
-// parent imposed during the measured pass, one commit later. When the content
-// doesn't fit its container that disagreement is visible as a scale flip on
-// every update. The JS self-sizing pass exists only for the old architecture,
-// which has no shadow-node measure.
+// Fabric self-sizes via the shadow node's measureContent; feeding the async
+// (unconstrained) onContentSizeChange size back as a style would override
+// parent clamps a commit later. The JS self-sizing pass is old-arch only.
 const IS_FABRIC =
   (globalThis as {nativeFabricUIManager?: unknown}).nativeFabricUIManager !=
   null;
+
+// One standard style for both host contexts: as a flex sibling alignSelf is
+// plain Yoga (shadow baseline()); inside <Text> — where text layout ignores
+// alignSelf — it is forwarded as the native `inlineAlign` shift. Gated by
+// TextAncestorContext so the two contexts can't double-apply.
+const INLINE_ALIGN_FROM_ALIGN_SELF: Partial<
+  Record<string, 'baseline' | 'center' | 'start' | 'end'>
+> = {
+  baseline: 'baseline',
+  center: 'center',
+  'flex-start': 'start',
+  'flex-end': 'end',
+};
 
 export function RaTeXView({
   latex,
@@ -104,15 +127,22 @@ export function RaTeXView({
   const hasWidth = typeof flatStyle?.width === 'number';
   const hasHeight = typeof flatStyle?.height === 'number';
 
-  const resolvedStyle = contentSize
-    ? [
-        style,
-        {
+  const hasTextAncestor = useContext(TextAncestorContext);
+  const inlineAlign =
+    (hasTextAncestor &&
+      flatStyle?.alignSelf != null &&
+      INLINE_ALIGN_FROM_ALIGN_SELF[flatStyle.alignSelf]) ||
+    'none';
+
+  const resolvedStyle = [
+    style,
+    contentSize
+      ? {
           ...(hasWidth ? {} : {width: contentSize.width}),
           ...(hasHeight ? {} : {height: contentSize.height}),
-        },
-      ]
-    : style;
+        }
+      : null,
+  ];
 
   return (
     <RaTeXViewNativeComponent
@@ -120,6 +150,7 @@ export function RaTeXView({
       latex={latex}
       fontSize={fontSize}
       displayMode={displayMode}
+      inlineAlign={inlineAlign}
       color={resolvedColor}
       style={resolvedStyle}
       onError={onError}

--- a/platforms/react-native/src/RaTeXView.tsx
+++ b/platforms/react-native/src/RaTeXView.tsx
@@ -3,12 +3,15 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useImperativeHandle,
+  useRef,
   useState,
 } from 'react';
 import * as ReactNative from 'react-native';
 import {StyleSheet} from 'react-native';
 import type {ColorValue, StyleProp, ViewStyle} from 'react-native';
 import RaTeXViewNativeComponent from './RaTeXViewNativeComponent';
+import {getTexMetrics as getNaturalTexMetrics} from './getTexMetrics';
 
 // True inside <Text> (reset by nested <View>) — "am I an inline attachment".
 // Native code can't tell: Android Fabric hoists inline views into the text's
@@ -43,8 +46,34 @@ export function RaTeXProvider({
   );
 }
 
-/** Instance handle of the underlying native view (measure, measureInWindow, …). */
-export type RaTeXViewRef = React.ComponentRef<typeof RaTeXViewNativeComponent>;
+/**
+ * `depth` is DRAWN (fit-scale and centering gap applied — never multiply by
+ * `scale`); `width`/`height` are NATURAL ink size; `scale` bridges the two.
+ */
+export interface RaTeXTexMetrics {
+  /** View bottom edge → drawn ink baseline, dp. */
+  depth: number;
+  /** Fit scale k (≤ 1). */
+  scale: number;
+  /** Natural ink width, dp. */
+  width: number;
+  /** Natural ink height, dp. */
+  height: number;
+}
+
+type NativeRaTeXViewInstance = React.ComponentRef<
+  typeof RaTeXViewNativeComponent
+>;
+
+/** The genuine host instance (measure, …) plus `getTexMetrics()`. */
+export type RaTeXViewRef = NativeRaTeXViewInstance & {
+  /**
+   * Sync TeX metrics at the committed layout (parse-cache-backed); null when
+   * unmounted, empty, or parse failed. Call from `useLayoutEffect` or later.
+   * Old arch: `measure` is async there, so metrics assume natural size.
+   */
+  getTexMetrics(): RaTeXTexMetrics | null;
+};
 
 export interface RaTeXViewProps {
   latex: string;
@@ -99,6 +128,59 @@ export function RaTeXView({
   } | null>(null);
   const resolvedColor = color ?? inheritedColor;
 
+  const nativeRef = useRef<NativeRaTeXViewInstance | null>(null);
+
+  const getTexMetrics = useCallback((): RaTeXTexMetrics | null => {
+    const node = nativeRef.current;
+    const natural = getNaturalTexMetrics(
+      latex,
+      fontSize,
+      displayMode,
+      resolvedColor,
+    );
+    if (!node || !natural || natural.width <= 0 || natural.height <= 0) {
+      return null;
+    }
+    // Sync on Fabric; async on old arch → frame stays 0,0 → scale 1, no gap.
+    let frameWidth = 0;
+    let frameHeight = 0;
+    node.measure((_x, _y, width, height) => {
+      frameWidth = width;
+      frameHeight = height;
+    });
+    // Mirrors the native drawing/baseline() math (fit-scale k + centering
+    // gap); pixel snapping and optical raise are host calibration, left out.
+    let scale = 1;
+    let gap = 0;
+    if (frameWidth > 0 && frameHeight > 0) {
+      scale = Math.min(
+        1,
+        frameWidth / natural.width,
+        frameHeight / natural.height,
+      );
+      gap = Math.max(0, (frameHeight - natural.height * scale) / 2);
+    }
+    return {
+      depth: gap + Math.max(0, natural.depth) * scale,
+      scale,
+      width: natural.width,
+      height: natural.height,
+    };
+  }, [latex, fontSize, displayMode, resolvedColor]);
+
+  // Exposes the GENUINE host instance, augmented with getTexMetrics (child
+  // refs attach before createHandle runs) — not a wrapper object, so host
+  // identity, findNodeHandle, and every host method survive.
+  useImperativeHandle(
+    ref,
+    () => {
+      const node = nativeRef.current as RaTeXViewRef;
+      node.getTexMetrics = getTexMetrics;
+      return node;
+    },
+    [getTexMetrics],
+  );
+
   // Old architecture only (contentSize is never set on Fabric): when inputs
   // change, drop the cached measurement so the view can shrink/grow instead of
   // keeping a stale width/height until the next event arrives.
@@ -146,7 +228,7 @@ export function RaTeXView({
 
   return (
     <RaTeXViewNativeComponent
-      ref={ref}
+      ref={nativeRef}
       latex={latex}
       fontSize={fontSize}
       displayMode={displayMode}

--- a/platforms/react-native/src/RaTeXViewNativeComponent.ts
+++ b/platforms/react-native/src/RaTeXViewNativeComponent.ts
@@ -3,6 +3,7 @@ import type {
   Float,
   BubblingEventHandler,
   DirectEventHandler,
+  WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type {ColorValue, HostComponent, ViewProps} from 'react-native';
@@ -16,6 +17,14 @@ export interface NativeProps extends ViewProps {
   /** true (default) = display/block style; false = inline/text style. */
   displayMode?: boolean;
   color?: ColorValue;
+  /**
+   * Internal — derived from `style.alignSelf` by RaTeXView, do not set directly.
+   * Vertical alignment of the formula against the surrounding text line when the
+   * view is embedded inside <Text>. RaTeXView only sets it under a <Text>
+   * ancestor (TextAncestorContext), so the same style in a flex row stays pure
+   * Yoga.
+   */
+  inlineAlign?: WithDefault<'none' | 'baseline' | 'center' | 'start' | 'end', 'none'>;
   onError?: BubblingEventHandler<OnErrorEvent>;
   onContentSizeChange?: DirectEventHandler<OnContentSizeChangeEvent>;
 }

--- a/platforms/react-native/src/getTexMetrics.ts
+++ b/platforms/react-native/src/getTexMetrics.ts
@@ -1,0 +1,38 @@
+import {processColor} from 'react-native';
+import type {ColorValue} from 'react-native';
+import NativeRaTeXModule from './NativeRaTeXModule';
+
+/** Natural (unscaled) formula ink metrics in dp at the given font size. */
+export interface RaTeXNaturalTexMetrics {
+  /** Ink width. */
+  width: number;
+  /** Total ink height (ascent + depth). */
+  height: number;
+  /** Descent below the baseline; the baseline sits at `height - depth`. */
+  depth: number;
+}
+
+/**
+ * Sync natural TeX metrics for a formula — no view needed. Backed by the
+ * parse cache the measure/render passes share. Null when empty, parse failed,
+ * or the native module is unavailable.
+ *
+ * `color` should match the render color so Android's color-keyed cache entry
+ * is shared with the on-screen view (iOS metrics are color-blind).
+ */
+export function getTexMetrics(
+  latex: string,
+  fontSize: number,
+  displayMode: boolean,
+  color?: ColorValue,
+): RaTeXNaturalTexMetrics | null {
+  const processed = processColor(color);
+  return (
+    NativeRaTeXModule?.getTexMetrics(
+      latex,
+      fontSize,
+      displayMode,
+      typeof processed === 'number' ? processed : 0xff000000,
+    ) ?? null
+  );
+}

--- a/platforms/react-native/src/index.ts
+++ b/platforms/react-native/src/index.ts
@@ -1,4 +1,11 @@
 export {RaTeXColorContext, RaTeXProvider, RaTeXView} from './RaTeXView';
-export type {RaTeXProviderProps, RaTeXViewProps, RaTeXViewRef} from './RaTeXView';
+export type {
+  RaTeXProviderProps,
+  RaTeXTexMetrics,
+  RaTeXViewProps,
+  RaTeXViewRef,
+} from './RaTeXView';
 export {InlineTeX} from './InlineTeX';
 export type {InlineTeXProps} from './InlineTeX';
+export {getTexMetrics} from './getTexMetrics';
+export type {RaTeXNaturalTexMetrics} from './getTexMetrics';


### PR DESCRIPTION
closes #130 

# feat(react-native): baseline alignment + `getTexMetrics()`

Inline math should sit on the text baseline like a glyph. This PR makes
`alignSelf: 'baseline'` work in both host contexts RN offers, and exposes the
formula's ink metrics for hosts that do their own text layout.

## 1. Flex row — `alignItems: 'baseline'`

```tsx
<View style={{ flexDirection: 'row', alignItems: 'baseline' }}>
  <Text>f(x) =</Text>
  <RaTeXView latex={'\\frac{a}{b}'} fontSize={16} displayMode={false} />
</View>
```

Works perfectly — Yoga lines the formula's ink baseline up with the text
baseline, at any font size and under `maxWidth` clamping. One platform
limitation (not this library's): the row is separate native nodes, so text
selection can't flow across it.

## 2. Inside `<Text>` — `alignSelf: 'baseline'`

```tsx
<Text>
  compare y with{' '}
  <RaTeXView latex="y" fontSize={16} displayMode={false}
             style={{ alignSelf: 'baseline' }} />{' '}
  mid-sentence
</Text>
```

The formula sits on the line's baseline like a glyph, line spacing matches
what a baseline flex row produces, and the paragraph stays real selectable
text. Same style as the flex case — no new public prop; `center` /
`flex-start` / `flex-end` work too.

Both cases are fully **opt-in**: no new props, and nothing changes unless you
set `alignSelf`. They also cover what `InlineTeX` can't — per-span styling,
nested components, and composing with an app-owned `<Text>` tree (e.g. a
markdown renderer).

**Known issue (bottom side, not fixable library-side).** RN's inline-view
protocol has no notion of depth: a line reserves only its *font's* descender
below the baseline. A formula much deeper than the text keeps its correct
baseline but its tail can overdraw the next line — where a flex row (blue)
reserves the full depth. Everything above the baseline is exact. Fixing this
needs depth in RN's attachment protocol itself.

| iOS | Android |
|---|---|
| ![deep-ios](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/deep-descender-ios.png) | ![deep-android](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/deep-descender-android.png) |

## 3. `getTexMetrics()` — text engines without the limitations

The two cases above are RN layout. A host that renders text itself — a
markdown renderer or editor built on **TextKit (iOS) / Spannables (Android)**
— has none of RN's inline limitations (real selection, real line breaking,
depth-aware lines), but it needs the formula's **depth** as a number to place
the attachment box. That's exactly what KaTeX ships on the web with every
formula (`.depth`, emitted as `vertical-align: -depth`).

On a mounted view — drawn metrics at the committed layout:

```tsx
const m = ref.current?.getTexMetrics();
// { depth, scale, width, height } | null
// depth: view bottom edge → drawn ink baseline, dp — apply directly
```

And the global function the ref method uses internally — natural metrics for
any formula, no view needed:

```tsx
import { getTexMetrics } from 'ratex-react-native';

const m = getTexMetrics('\\frac{a}{b}', 16, false);
// { width, height, depth } | null — natural (unscaled) ink size, dp
```

Both are sync (callable in `useLayoutEffect`) and served from the parse cache
the measure/render passes share, so an on-screen formula never re-parses.
Cold parse is ~0.2 ms per formula (release builds); a cache hit is
microseconds.

This is enough to build your own `InlineTeX`-style engine with none of the
limitations above. The screenshot below is such a host (TextKit/Spannables +
`getTexMetrics`): selectable, per-span styling, and the line holding the deep
formula reserves its full depth — no overdraw:

![custom engine](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/custom-engine-deep.png)

## Screenshots

All examples from `demo/react-native-expo` (iPhone 17 Pro simulator / Pixel 9a
emulator, RN 0.86, new arch). Amber = inline in `<Text>`, blue = flex
baseline (ground truth), red = no alignment. Full-size images in
[istarkov/RaTeX#1](https://github.com/istarkov/RaTeX/issues/1).

| Example | iOS | Android |
|---|---|---|
| Flex row: Yoga aligns | ![](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/yogaaligns-ios.png) | ![](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/yogaaligns-android.png) |
| Inside `<Text>` vs flex (full card) | ![](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/inline-baseline-ios.png) | ![](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/inline-baseline-android.png) |
| 3-line wrap: plain line above the formula line | ![](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/neighbors-ios.png) | ![](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/neighbors-android.png) |
| Known issue: deep descender | ![](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/deep-descender-ios.png) | ![](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/deep-descender-android.png) |
| In-`<Text>` `alignSelf` options | ![](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/align-options-ios.png) | ![](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/align-options-android.png) |
| Baseline × font size mix | ![](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/fontsizemix-ios.png) | ![](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/fontsizemix-android.png) |
| maxWidth autoscaling × baseline | ![](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/maxwidth-ios.png) | ![](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/maxwidth-android.png) |
| `getTexMetrics()` depth ruler | ![](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/texmetrics-ios.png) | ![](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/texmetrics-android.png) |
| `getTexMetrics()` perf card | ![](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/perf-ios.png) | ![](https://raw.githubusercontent.com/istarkov/RaTeX/baseline-align-assets/perf-android.png) |

## Design decisions

- **No new public prop for alignment** — the standard `alignSelf` style works
  in both host contexts; native applies the placement itself.
- **Depth is exposed as a method, not a prop/event** — it's a value you pull
  at layout time; both forms are sync so they work inside `useLayoutEffect`.
- **Two shapes on purpose**: the ref method returns *drawn* metrics (fit
  scale + centering applied — apply `depth` directly at the committed size);
  the global function returns *natural* metrics for engines that lay out
  before mounting.
- **Everything rides the existing parse cache** — measure, render, baseline
  and metrics share one parsed representation per formula; no extra parses.
- Prior art: KaTeX's `.depth` / `vertical-align: -depth` on the web.

## Technical details (brief)

- Flex baseline: the Fabric shadow node implements `baseline()` — drawn ink
  baseline (fit scale ≤ 1 + centering gap + TeX depth), pixel-grid snapped.
- Inside `<Text>`: RN reserves an inline view's full height as line *ascent*,
  so for `'baseline'` the node measures the ascent-only box (`height − depth`)
  and draws bottom-anchored, descender overflowing — line spacing matches the
  flex row. JS forwards `alignSelf` through an internal codegen prop
  (`inlineAlign`) gated by `TextAncestorContext`.
- iOS additionally compensates a stock-RN TextKit sink bug at runtime
  (inline attachment run has no font attribute); self-disabling on a fixed RN.
- `getTexMetrics` is a thin sync TurboModule (`RaTeXModule`, old + new arch)
  over the existing `RaTeXMeasure` / `RaTeXMetrics` backends; the ref stays a
  genuine host instance (`measure` etc. untouched).
- No breaking changes. Verified on stock RN 0.86, both platforms, old + new
  arch (metrics fall back to natural size on old arch, where `measure` is
  async).
