### PR TITLE
fix(ios): build XCFramework with panic-abort std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,9 +153,11 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
+      - name: Install iOS Rust toolchain
+        run: |
+          rustup toolchain install nightly-2026-08-16 --profile minimal --component rust-src
+          rustup target add --toolchain nightly-2026-08-16 \
+            aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
       - uses: Swatinem/rust-cache@v2
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/release-flutter.yml
+++ b/.github/workflows/release-flutter.yml
@@ -50,6 +50,12 @@ jobs:
             x86_64-unknown-linux-gnu,
             aarch64-unknown-linux-gnu
 
+      - name: Install Apple Rust toolchain
+        run: |
+          rustup toolchain install nightly-2026-08-16 --profile minimal --component rust-src
+          rustup target add --toolchain nightly-2026-08-16 \
+            aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -25,6 +25,12 @@ jobs:
             aarch64-apple-darwin,
             x86_64-apple-darwin
 
+      - name: Install iOS Rust toolchain
+        run: |
+          rustup toolchain install nightly-2026-08-16 --profile minimal --component rust-src
+          rustup target add --toolchain nightly-2026-08-16 \
+            aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/release-react-native.yml
+++ b/.github/workflows/release-react-native.yml
@@ -52,6 +52,12 @@ jobs:
             aarch64-apple-darwin,
             x86_64-apple-darwin
 
+      - name: Install Apple Rust toolchain
+        run: |
+          rustup toolchain install nightly-2026-08-16 --profile minimal --component rust-src
+          rustup target add --toolchain nightly-2026-08-16 \
+            aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
 

--- a/scripts/build-apple-xcframework.sh
+++ b/scripts/build-apple-xcframework.sh
@@ -2,7 +2,9 @@
 # build-apple-xcframework.sh — Build RaTeX.xcframework for iOS + macOS
 #
 # Prerequisites:
-#   rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+#   rustup toolchain install nightly-2026-08-16 --component rust-src
+#   rustup target add --toolchain nightly-2026-08-16 \
+#     aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
 #   rustup target add aarch64-apple-darwin x86_64-apple-darwin
 #   Xcode command-line tools installed
 #
@@ -26,6 +28,7 @@ HEADER_DIR="$REPO_ROOT/crates/ratex-ffi/include"
 OUTPUT="$REPO_ROOT/platforms/ios/RaTeX.xcframework"
 BUILD_IOS=true
 BUILD_MACOS=true
+IOS_RUST_TOOLCHAIN="${RATEX_IOS_RUST_TOOLCHAIN:-nightly-2026-08-16}"
 # Controls missing-target behavior:
 # - auto (default): auto-install locally, fail in CI
 # - true: always auto-install
@@ -40,6 +43,14 @@ for arg in "$@"; do
 done
 
 LIBS=()
+
+build_ios_target() {
+  local target="$1"
+  cargo +"$IOS_RUST_TOOLCHAIN" build \
+      -Z build-std=std,panic_abort \
+      --release -p ratex-ffi --manifest-path "$REPO_ROOT/Cargo.toml" \
+      --target "$target"
+}
 
 ensure_rust_target_installed() {
   local target="$1"
@@ -84,12 +95,9 @@ $target
 # ---------------------------------------------------------------------------
 if $BUILD_IOS; then
   echo "==> Building ratex-ffi for iOS targets..."
-  cargo build --release -p ratex-ffi --manifest-path "$REPO_ROOT/Cargo.toml" \
-      --target aarch64-apple-ios
-  cargo build --release -p ratex-ffi --manifest-path "$REPO_ROOT/Cargo.toml" \
-      --target aarch64-apple-ios-sim
-  cargo build --release -p ratex-ffi --manifest-path "$REPO_ROOT/Cargo.toml" \
-      --target x86_64-apple-ios
+  build_ios_target aarch64-apple-ios
+  build_ios_target aarch64-apple-ios-sim
+  build_ios_target x86_64-apple-ios
 
   echo "==> Creating fat iOS simulator binary..."
   SIM_DIR=$(mktemp -d)
@@ -100,6 +108,11 @@ if $BUILD_IOS; then
 
   LIBS+=(-library "$REPO_ROOT/target/aarch64-apple-ios/release/libratex_ffi.a" -headers "$HEADER_DIR")
   LIBS+=(-library "$SIM_DIR/libratex_ffi.a" -headers "$HEADER_DIR")
+
+  echo "==> Verifying iOS static libraries do not reference Rust's unwind personality..."
+  bash "$REPO_ROOT/scripts/verify-apple-static-libraries.sh" \
+      "$REPO_ROOT/target/aarch64-apple-ios/release/libratex_ffi.a" \
+      "$SIM_DIR/libratex_ffi.a"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/verify-apple-static-libraries.sh
+++ b/scripts/verify-apple-static-libraries.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Fail if an iOS static library's unwind metadata references Rust's personality
+# routine. Generic compiler_builtins unwind entries without a personality are
+# valid and do not consume a compact-unwind personality slot.
+
+set -euo pipefail
+
+if [[ "$#" -lt 1 ]]; then
+  echo "Usage: $0 <static-library> [static-library ...]" >&2
+  exit 2
+fi
+
+if ! command -v otool >/dev/null 2>&1; then
+  echo "::error::otool is required to inspect Apple static libraries." >&2
+  exit 1
+fi
+
+for library in "$@"; do
+  if [[ ! -f "$library" ]]; then
+    echo "::error::Static library not found: $library" >&2
+    exit 1
+  fi
+
+  for arch in $(lipo -archs "$library"); do
+    personality_relocations="$(
+      otool -arch "$arch" -rv "$library" |
+        awk '$NF == "_rust_eh_personality" { count++ } END { print count + 0 }'
+    )"
+
+    if [[ "$personality_relocations" -ne 0 ]]; then
+      echo "::error::_rust_eh_personality is referenced by unwind metadata in $library ($arch): $personality_relocations relocation(s)" >&2
+      exit 1
+    fi
+
+    echo "No _rust_eh_personality unwind relocations: $library ($arch)"
+  done
+done
+
+echo "iOS static library personality check passed."


### PR DESCRIPTION
## Summary

- build the iOS `ratex-ffi` static libraries with a pinned nightly toolchain, `rust-src`, and `-Z build-std=std,panic_abort`
- install that toolchain in every CI and release workflow that produces the iOS XCFramework
- verify every iOS architecture has no `_rust_eh_personality` relocations before packaging
- keep the existing stable-toolchain macOS build unchanged

## Root cause

`panic = "abort"` in the release profile only affects crates compiled from source. The rustup-distributed precompiled standard library is built with unwinding, and those objects are bundled into the published static library. Their unwind metadata references `_rust_eh_personality`, which makes it count against Apple's compact-unwind personality limit in applications that also link Swift, Objective-C, and C++ code.

Rebuilding `std` with `panic_abort` removes those references at the source. A defined but unreferenced `_rust_eh_personality` symbol may remain; it does not consume a compact-unwind personality slot.

The verification intentionally checks personality relocations rather than requiring every unwind section to disappear. The x86_64 simulator build can retain generic `compiler_builtins` unwind entries that do not reference a personality and are safe for this issue.

## Validation

- built the combined iOS and macOS XCFramework successfully
- verified iOS device `arm64` and simulator `arm64` / `x86_64` slices contain zero `_rust_eh_personality` relocations
- verified the existing platform/architecture slice check passes for iOS and macOS
- verified the published v0.1.14 iOS device library is rejected by the new guard with 18 `_rust_eh_personality` relocations
- checked shell syntax, workflow YAML parsing, and `git diff --check`

Closes #151
